### PR TITLE
feat(checker): add ready and noop

### DIFF
--- a/pkg/checker/noop_checker.go
+++ b/pkg/checker/noop_checker.go
@@ -1,0 +1,19 @@
+package checker
+
+import (
+	"context"
+)
+
+// NewNoopChecker with no functionality.
+func NewNoopChecker() *NoopChecker {
+	return &NoopChecker{}
+}
+
+// NoopChecker with no functionality.
+type NoopChecker struct {
+}
+
+// Check does a NOOP.
+func (c *NoopChecker) Check(ctx context.Context) error {
+	return nil
+}

--- a/pkg/checker/ready_checker.go
+++ b/pkg/checker/ready_checker.go
@@ -1,0 +1,35 @@
+package checker
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+// NewReadyChecker with a specific error.
+func NewReadyChecker(err error) *ReadyChecker {
+	return &ReadyChecker{err: err}
+}
+
+// ReadyChecker for when prepared for something.
+type ReadyChecker struct {
+	flag int32
+	err  error
+}
+
+// Check the if ready.
+func (c *ReadyChecker) Check(ctx context.Context) error {
+	if c.notReady() {
+		return c.err
+	}
+
+	return nil
+}
+
+// Ready marks the checker as done.
+func (c *ReadyChecker) Ready() {
+	atomic.StoreInt32(&(c.flag), 1)
+}
+
+func (c *ReadyChecker) notReady() bool {
+	return atomic.LoadInt32(&(c.flag)) == 0
+}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -358,6 +358,37 @@ func TestValidReadyChecker(t *testing.T) {
 	})
 }
 
+func TestValidNoopChecker(t *testing.T) {
+	Convey("Given we have a new server", t, func() {
+		s := server.NewServer()
+		defer s.Stop() // nolint:errcheck
+
+		name := "noop"
+		checker := checker.NewNoopChecker()
+		r := server.NewRegistration(name, defaultPeriod(), checker)
+
+		_ = s.Register(r)
+
+		ob, _ := s.Observe(name)
+
+		Convey("When I start the server", func() {
+			err := s.Start()
+
+			Convey("Then I should have no server error", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then I should have no error from the observer", func() {
+				So(ob.Error(), ShouldBeNil)
+
+				time.Sleep(defaultWait())
+
+				So(ob.Error(), ShouldBeNil)
+			})
+		})
+	})
+}
+
 func TestInvalidObserver(t *testing.T) {
 	Convey("Given we have a new server", t, func() {
 		s := server.NewServer()

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,6 +1,7 @@
 package server_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -313,6 +314,42 @@ func TestValidDBChecker(t *testing.T) {
 			})
 
 			Convey("Then I should have no error from the observer", func() {
+				time.Sleep(defaultWait())
+
+				So(ob.Error(), ShouldBeNil)
+			})
+		})
+	})
+}
+
+func TestValidReadyChecker(t *testing.T) {
+	Convey("Given we have a new server", t, func() {
+		s := server.NewServer()
+		defer s.Stop() // nolint:errcheck
+
+		name := "ready"
+		err := errors.New("not ready")
+		checker := checker.NewReadyChecker(err)
+		r := server.NewRegistration(name, defaultPeriod(), checker)
+
+		_ = s.Register(r)
+
+		ob, _ := s.Observe(name)
+
+		Convey("When I start the server", func() {
+			err := s.Start()
+
+			Convey("Then I should have no server error", func() {
+				So(err, ShouldBeNil)
+			})
+
+			Convey("Then I should have an error from the observer", func() {
+				So(ob.Error(), ShouldEqual, err)
+			})
+
+			Convey("Then I should have no error from the observer", func() {
+				checker.Ready()
+
 				time.Sleep(defaultWait())
 
 				So(ob.Error(), ShouldBeNil)


### PR DESCRIPTION
We have added 2 checkers:
- Ready (useful for readiness probes)
- NOOP useful if you just want to have it setup and do nothing (sometime we use this for health checks)