### PR TITLE
feat(context): use package timeout causes for db and tcp checkers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,6 +137,7 @@ There are also `sync`, `version`, and `wait-all` jobs in `.circleci/config.yml`.
 ### Errors
 
 - Checkers wrap underlying failures with context, usually using `fmt.Errorf("<checker>: %w", err)`.
+- `checker.DBChecker` and `checker.TCPChecker` use `checker.ErrTimeout` as the cause for their derived timeout contexts.
 - Aggregated observer errors use `errors.Join`.
 - `subscriber.Errors.Error` annotates each joined error with the probe name.
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ import "github.com/alexfalkowski/go-health/v2/server"
 - `probe.Start` performs an immediate check before the periodic loop continues.
 - A probe with an invalid period emits a single error tick and closes.
 - `HTTPChecker`, `TCPChecker`, `DBChecker`, and `OnlineChecker` use a default timeout of `30s` when you pass `0`.
+- `DBChecker` and `TCPChecker` use `checker.ErrTimeout` as the timeout cause for their derived per-call contexts.
 - `OnlineChecker` reports healthy if any configured URL returns `200 OK` or `204 No Content`.
 - `subscriber.Observer` starts with `nil` errors for every tracked probe name and updates as ticks arrive.
 - `server.Service` and `server.Server` keep observer instances across stop/start cycles, so existing observers continue receiving ticks after a restart.

--- a/checker/db.go
+++ b/checker/db.go
@@ -12,8 +12,8 @@ var _ Checker = (*DBChecker)(nil)
 
 // NewDBChecker returns a DBChecker that pings pinger.
 //
-// The timeout is applied via context.WithTimeout during Check. Passing 0 uses
-// the package default of 30 seconds.
+// The timeout is applied via [context.WithTimeoutCause] during Check. Passing 0
+// uses the package default of 30 seconds.
 func NewDBChecker(pinger sql.Pinger, t time.Duration) *DBChecker {
 	return &DBChecker{pinger: pinger, timeout: timeout(t)}
 }
@@ -28,8 +28,11 @@ type DBChecker struct {
 }
 
 // Check pings the database with a per-call timeout.
+//
+// If the timeout expires and the pinger returns [context.Cause], the returned
+// error matches [ErrTimeout].
 func (c *DBChecker) Check(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, c.timeout, ErrTimeout)
 	defer cancel()
 
 	if err := c.pinger.PingContext(ctx); err != nil {

--- a/checker/doc.go
+++ b/checker/doc.go
@@ -22,6 +22,9 @@
 //
 // HTTPChecker, TCPChecker, DBChecker, and OnlineChecker accept a timeout
 // duration. Passing 0 uses a default timeout of 30 seconds.
+// DBChecker and TCPChecker derive per-call contexts using [context.WithTimeoutCause].
+// If their underlying dependency returns [context.Cause] after that timeout
+// expires, the resulting error matches [ErrTimeout].
 //
 // OnlineChecker uses a built-in list of connectivity endpoints unless you
 // override it with WithURLs. HTTPChecker and OnlineChecker use

--- a/checker/tcp.go
+++ b/checker/tcp.go
@@ -12,9 +12,9 @@ var _ Checker = (*TCPChecker)(nil)
 
 // NewTCPChecker returns a TCPChecker that connects to address.
 //
-// The timeout is applied via context.WithTimeout during Check. Passing 0 uses
-// the package default of 30 seconds. Use WithDialer to override the dialing
-// implementation.
+// The timeout is applied via [context.WithTimeoutCause] during Check. Passing 0
+// uses the package default of 30 seconds. Use WithDialer to override the
+// dialing implementation.
 func NewTCPChecker(address string, t time.Duration, opts ...Option) *TCPChecker {
 	os := parseOptions(opts...)
 
@@ -32,8 +32,11 @@ type TCPChecker struct {
 }
 
 // Check attempts to connect to the configured address with a per-call timeout.
+//
+// If the timeout expires and the dialer returns [context.Cause], the returned
+// error matches [ErrTimeout].
 func (c *TCPChecker) Check(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, c.timeout)
+	ctx, cancel := context.WithTimeoutCause(ctx, c.timeout, ErrTimeout)
 	defer cancel()
 
 	conn, err := c.dialer.DialContext(ctx, "tcp", c.address)

--- a/checker/timeout.go
+++ b/checker/timeout.go
@@ -1,6 +1,17 @@
 package checker
 
-import "time"
+import (
+	"fmt"
+	"time"
+
+	"github.com/alexfalkowski/go-sync"
+)
+
+// ErrTimeout is the timeout cause used by derived checker contexts.
+//
+// It wraps [sync.ErrTimeout], so [errors.Is] also matches
+// [context.DeadlineExceeded].
+var ErrTimeout = fmt.Errorf("checker: %w", sync.ErrTimeout)
 
 func timeout(t time.Duration) time.Duration {
 	if t == 0 {

--- a/checker/timeout_test.go
+++ b/checker/timeout_test.go
@@ -1,0 +1,49 @@
+package checker_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/alexfalkowski/go-health/v2/checker"
+	"github.com/alexfalkowski/go-health/v2/sql"
+	"github.com/alexfalkowski/go-sync"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDBCheckerTimeoutCause(t *testing.T) {
+	c := checker.NewDBChecker(timeoutPinger{}, time.Microsecond)
+
+	err := c.Check(t.Context())
+
+	require.ErrorIs(t, err, checker.ErrTimeout)
+	require.ErrorIs(t, err, sync.ErrTimeout)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestTCPCheckerTimeoutCause(t *testing.T) {
+	c := checker.NewTCPChecker("example:80", time.Microsecond, checker.WithDialer(timeoutDialer{}))
+
+	err := c.Check(t.Context())
+
+	require.ErrorIs(t, err, checker.ErrTimeout)
+	require.ErrorIs(t, err, sync.ErrTimeout)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+type timeoutPinger struct{}
+
+func (timeoutPinger) PingContext(ctx context.Context) error {
+	<-ctx.Done()
+	return context.Cause(ctx)
+}
+
+var _ sql.Pinger = timeoutPinger{}
+
+type timeoutDialer struct{}
+
+func (timeoutDialer) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
+	<-ctx.Done()
+	return nil, context.Cause(ctx)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/alexfalkowski/go-health/v2
 go 1.26.0
 
 require (
-	github.com/alexfalkowski/go-sync v1.19.3
+	github.com/alexfalkowski/go-sync v1.20.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/alexfalkowski/go-sync v1.19.3 h1:sEmPvRa08IjuQ44YpglQDhXpbex1YPQCwRkKqarejQc=
-github.com/alexfalkowski/go-sync v1.19.3/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
+github.com/alexfalkowski/go-sync v1.20.0 h1:p9GTlXKhncDY2sPLknsCQjYGtp6DvrRX6/sctThts78=
+github.com/alexfalkowski/go-sync v1.20.0/go.mod h1:J2yBCIWJ1YAWqAJ94Bt2xroR2rOWlSyRBGqqNJDmLBw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
## What

Add a package-owned `checker.ErrTimeout` and use it as the timeout cause for `DBChecker` and `TCPChecker` via `context.WithTimeoutCause`. Update checker docs and repository docs to describe the new timeout error behavior, and add focused timeout regression tests for both checkers.

## Why

This makes checker timeout errors explicit and owned by `go-health` while preserving `errors.Is` compatibility with `sync.ErrTimeout` and `context.DeadlineExceeded`. It also aligns this repo with the same timeout-cause pattern used in the related libraries.

## Testing

- Added timeout regression tests for `DBChecker` and `TCPChecker`
- Ran `env GOCACHE=/tmp/go-build GOTMPDIR=/tmp go test ./checker -count=1`
- Ran `env GOCACHE=/tmp/go-build GOTMPDIR=/tmp go test ./checker ./probe ./subscriber ./net ./sql -count=1`
- Ran `env GOCACHE=/tmp/go-build GOTMPDIR=/tmp go test ./...` and saw an existing environment-dependent failure in `server` (`TestValidObserver` could not reach `localhost:15000`)