### PR TITLE
docs(service): server start and stop lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ import "github.com/alexfalkowski/go-health/v2/server"
 ## Key behaviors
 
 - `probe.Start` performs an immediate check before the periodic loop continues.
+- `server.Start` waits for each service's initial checks before returning; call
+  `Stop` after `Start` returns, typically during process shutdown.
 - A probe with an invalid period emits a single error tick and closes.
 - `HTTPChecker`, `TCPChecker`, `DBChecker`, and `OnlineChecker` use a default timeout of `30s` when you pass `0`.
 - `DBChecker` and `TCPChecker` use `checker.ErrTimeout` as the timeout cause for their derived per-call contexts.

--- a/server/doc.go
+++ b/server/doc.go
@@ -12,8 +12,10 @@
 // create one or more observers, usually named after an endpoint such as "livez"
 // or "readyz", that watch a subset of those probe names.
 //
-// Configure services and observers during setup, then call Start and Stop to run
-// the orchestration. Existing observers continue to work across service restarts.
+// Configure services and observers during setup, then call Start to run the
+// orchestration. Start waits for initial checks to finish before returning. Call
+// Stop after Start has returned, typically from process shutdown. Existing
+// observers continue to work across service restarts.
 //
 // # Example
 //

--- a/server/server.go
+++ b/server/server.go
@@ -20,7 +20,8 @@ func NewServer() *Server {
 // Server maintains registered services and can start or stop them as a group.
 //
 // Register and Observe are intended for setup time. Call Start once the server
-// has been configured, and Stop when the process is shutting down.
+// has been configured, and Stop after Start has returned when the process is
+// shutting down.
 type Server struct {
 	services map[string]*Service
 	mux      sync.Mutex
@@ -79,7 +80,8 @@ func (s *Server) Observe(name, kind string, names ...string) error {
 
 // Start starts all registered services.
 //
-// Start is idempotent.
+// Start is idempotent. It waits for each service's initial checks before
+// returning; call Stop after Start has returned during normal shutdown.
 func (s *Server) Start() {
 	s.mux.Lock()
 	defer s.mux.Unlock()

--- a/server/service.go
+++ b/server/service.go
@@ -32,8 +32,9 @@ func NewService() *Service {
 // Service maintains probes, subscribers, and observers for a single service.
 //
 // Register and Observe are typically called during setup. Start begins running
-// all probes and fan-outs their ticks to subscribers. Stop tears everything down
-// and preserves observers so the service can be started again later.
+// all probes, waits for their initial checks, and fan-outs their ticks to
+// subscribers. Stop tears everything down after Start has returned and preserves
+// observers so the service can be started again later.
 type Service struct {
 	registry      map[string]*probe.Probe
 	observers     map[string]*subscriber.Observer
@@ -86,7 +87,8 @@ func (s *Service) Observe(kind string, names ...string) error {
 // Start starts all registered probes and begins fan-out to subscribers.
 //
 // Existing observers continue receiving updates if the service is stopped and
-// started again later.
+// started again later. Start waits for each probe's initial check before
+// returning; call Stop after Start has returned during normal shutdown.
 func (s *Service) Start() {
 	s.mux.Lock()
 	defer s.mux.Unlock()


### PR DESCRIPTION
## What

Clarifies the documented lifecycle for `server.Server` and `server.Service`:

- `Start` waits for initial checks before returning.
- `Stop` is intended to be called after `Start` returns, typically during shutdown.
- README key behaviors now mention the same `Start` / `Stop` expectation.

## Why

This makes the intended usage explicit without adding extra concurrency machinery for unsupported `Stop`-while-`Start` scenarios.

## Testing

Passed:

```sh
make lint
go test ./probe ./server -run 'TestStopCancelsInFlightCheck|TestServiceStartStopGuards|TestRestartKeepsObserverReceivingTicks|TestServiceObserveRejectsUnknownProbes' -count=1
go test ./checker ./probe ./subscriber ./net ./sql -count=1
```