### PR TITLE
docs(service): server lifecycle expectations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ import "github.com/alexfalkowski/go-health/v2/server"
 ## Key behaviors
 
 - `probe.Start` performs an immediate check before the periodic loop continues.
+- `server.Register` and `server.Observe` are setup-time calls; finish
+  registration before calling `Start`.
 - `server.Start` waits for each service's initial checks before returning; call
   `Stop` after `Start` returns, typically during process shutdown.
 - A probe with an invalid period emits a single error tick and closes.

--- a/server/doc.go
+++ b/server/doc.go
@@ -12,7 +12,7 @@
 // create one or more observers, usually named after an endpoint such as "livez"
 // or "readyz", that watch a subset of those probe names.
 //
-// Configure services and observers during setup, then call Start to run the
+// Register services and observers during setup, then call Start to run the
 // orchestration. Start waits for initial checks to finish before returning. Call
 // Stop after Start has returned, typically from process shutdown. Existing
 // observers continue to work across service restarts.

--- a/server/server.go
+++ b/server/server.go
@@ -19,9 +19,9 @@ func NewServer() *Server {
 
 // Server maintains registered services and can start or stop them as a group.
 //
-// Register and Observe are intended for setup time. Call Start once the server
-// has been configured, and Stop after Start has returned when the process is
-// shutting down.
+// Register and Observe are setup-time calls. Call Start once the server has
+// been configured, and Stop after Start has returned when the process is shutting
+// down.
 type Server struct {
 	services map[string]*Service
 	mux      sync.Mutex
@@ -30,7 +30,8 @@ type Server struct {
 
 // Register adds a service with name and registrations.
 //
-// If a service already exists for name, it is replaced.
+// Register is intended for setup before Start. If a service already exists for
+// name, it is replaced.
 func (s *Server) Register(name string, regs ...*Registration) {
 	service := NewService()
 	service.Register(regs...)
@@ -67,8 +68,8 @@ func (s *Server) Observer(name, kind string) (*subscriber.Observer, error) {
 
 // Observe registers an observer kind for the service name.
 //
-// The observer will track the probes listed in names. Repeated calls with the
-// same service and kind are idempotent.
+// Observe is intended for setup before Start. The observer will track the probes
+// listed in names. Repeated calls with the same service and kind are idempotent.
 func (s *Server) Observe(name, kind string, names ...string) error {
 	service, ok := s.services[name]
 	if !ok {

--- a/server/service.go
+++ b/server/service.go
@@ -31,10 +31,10 @@ func NewService() *Service {
 
 // Service maintains probes, subscribers, and observers for a single service.
 //
-// Register and Observe are typically called during setup. Start begins running
-// all probes, waits for their initial checks, and fan-outs their ticks to
-// subscribers. Stop tears everything down after Start has returned and preserves
-// observers so the service can be started again later.
+// Register and Observe are setup-time calls. Start begins running all probes,
+// waits for their initial checks, and fan-outs their ticks to subscribers. Stop
+// tears everything down after Start has returned and preserves observers so the
+// service can be started again later.
 type Service struct {
 	registry      map[string]*probe.Probe
 	observers     map[string]*subscriber.Observer
@@ -50,7 +50,8 @@ type Service struct {
 
 // Register registers all the given probe registrations.
 //
-// Later registrations with the same name replace earlier ones.
+// Register is intended for setup before Start. Later registrations with the same
+// name replace earlier ones.
 func (s *Service) Register(regs ...*Registration) {
 	for _, reg := range regs {
 		s.registry[reg.Name] = probe.NewProbe(reg.Name, reg.Period, reg.Checker)
@@ -69,8 +70,9 @@ func (s *Service) Observer(kind string) (*subscriber.Observer, error) {
 
 // Observe registers an observer kind that tracks the probes listed in names.
 //
-// It returns an error if any probe name has not been registered. Repeated calls
-// with the same kind are idempotent and keep the original probe set.
+// Observe is intended for setup before Start. It returns an error if any probe
+// name has not been registered. Repeated calls with the same kind are idempotent
+// and keep the original probe set.
 func (s *Service) Observe(kind string, names ...string) error {
 	_, ok := s.observers[kind]
 	if !ok {


### PR DESCRIPTION
## What

Clarifies server lifecycle documentation:

- `Register` and `Observe` are setup-time calls.
- Registration should be completed before calling `Start`.
- `Start` waits for initial checks before returning.
- `Stop` should be called after `Start` returns, typically during shutdown.

## Why

This documents the intended lifecycle contract without adding runtime machinery for unsupported registration or stop/start interleavings.

## Testing

Passed:

```sh
make lint
go test ./probe ./server -run 'TestStopCancelsInFlightCheck|TestServiceStartStopGuards|TestRestartKeepsObserverReceivingTicks|TestServiceObserveRejectsUnknownProbes' -count=1
go test ./checker ./probe ./subscriber ./net ./sql -count=1
```