### PR TITLE
fix(checker): clone online checker urls

### DIFF
--- a/checker/online_test.go
+++ b/checker/online_test.go
@@ -1,0 +1,30 @@
+package checker_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alexfalkowski/go-health/v2/checker"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOnlineCheckerClonesURLs(t *testing.T) {
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(healthy.Close)
+
+	unhealthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(unhealthy.Close)
+
+	urls := []string{healthy.URL}
+	check := checker.NewOnlineChecker(time.Second, checker.WithURLs(urls...))
+
+	urls[0] = unhealthy.URL
+
+	require.NoError(t, check.Check(t.Context()))
+}

--- a/checker/options.go
+++ b/checker/options.go
@@ -2,6 +2,7 @@ package checker
 
 import (
 	"net/http"
+	"slices"
 
 	"github.com/alexfalkowski/go-health/v2/net"
 )
@@ -45,7 +46,7 @@ func WithDialer(dialer net.Dialer) Option {
 // Providing at least one URL replaces the package defaults entirely.
 func WithURLs(urls ...string) Option {
 	return optionFunc(func(o *options) {
-		o.urls = urls
+		o.urls = slices.Clone(urls)
 	})
 }
 


### PR DESCRIPTION
## What

Updates `checker.WithURLs` to clone the provided URL slice before storing it.

Adds a regression test that mutates the caller-owned slice after constructing an `OnlineChecker` and verifies the checker still uses the original URL.

## Why

Prevents caller mutations from changing checker behavior after construction and avoids possible races if the caller mutates the slice while checks are running.

## Testing

Passed:

```sh
go test ./checker -run 'TestOnlineCheckerClonesURLs|ExampleNewOnlineChecker' -count=1
go test ./checker ./probe ./subscriber ./net ./sql -count=1
make lint
```