### PR TITLE
feat(checker): return after first healthy url

### DIFF
--- a/checker/online.go
+++ b/checker/online.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"time"
-
-	"github.com/alexfalkowski/go-sync"
 )
 
 var _ Checker = (*OnlineChecker)(nil)
@@ -46,32 +44,41 @@ type OnlineChecker struct {
 // errors are ignored unless every configured URL fails or returns an unexpected
 // status code.
 func (c *OnlineChecker) Check(ctx context.Context) error {
-	var counter sync.Int32
-	var wg sync.WaitGroup
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 
+	results := make(chan bool, len(c.urls))
 	for _, url := range c.urls {
-		wg.Go(func() {
-			req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
-			if err != nil {
-				return
+		go func() {
+			healthy := c.check(ctx, url)
+			if healthy {
+				cancel()
 			}
 
-			resp, err := c.client.Do(req)
-			if err != nil {
-				return
-			}
-			defer resp.Body.Close()
-
-			if resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent {
-				counter.Add(1)
-			}
-		})
+			results <- healthy
+		}()
 	}
 
-	wg.Wait()
-
-	if counter.Load() == 0 {
-		return fmt.Errorf("online checker: %w", ErrNotOnline)
+	for range c.urls {
+		if <-results {
+			return nil
+		}
 	}
-	return nil
+
+	return fmt.Errorf("online checker: %w", ErrNotOnline)
+}
+
+func (c *OnlineChecker) check(ctx context.Context, url string) bool {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
+	if err != nil {
+		return false
+	}
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+
+	return resp.StatusCode == http.StatusOK || resp.StatusCode == http.StatusNoContent
 }

--- a/checker/online_test.go
+++ b/checker/online_test.go
@@ -28,3 +28,35 @@ func TestOnlineCheckerClonesURLs(t *testing.T) {
 
 	require.NoError(t, check.Check(t.Context()))
 }
+
+func TestOnlineCheckerReturnsOnFirstHealthyURL(t *testing.T) {
+	slowStarted := make(chan struct{})
+	slowCanceled := make(chan struct{})
+	slow := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		close(slowStarted)
+		<-r.Context().Done()
+		close(slowCanceled)
+	}))
+	t.Cleanup(slow.Close)
+
+	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		<-slowStarted
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(healthy.Close)
+
+	check := checker.NewOnlineChecker(5*time.Second, checker.WithURLs(slow.URL, healthy.URL))
+
+	started := time.Now()
+	require.NoError(t, check.Check(t.Context()))
+
+	require.Less(t, time.Since(started), 500*time.Millisecond)
+	require.Eventually(t, func() bool {
+		select {
+		case <-slowCanceled:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, 10*time.Millisecond)
+}


### PR DESCRIPTION
## What

- Cancel sibling online checks after the first healthy response.
- Add regression coverage for a slow URL alongside a healthy URL.

## Why

- Online checks should not wait for slow fallback URLs once connectivity is confirmed.

## Testing

- `go test ./checker`
- `go test -race ./checker`
- `make lint` (passes with existing `gomodguard` deprecation warning)

AI-assisted-by: [Codex](https://openai.com/codex/)
