### PR TITLE
feat(server): run initial checks concurrently

### DIFF
--- a/server/service.go
+++ b/server/service.go
@@ -101,12 +101,7 @@ func (s *Service) Start() {
 
 	s.prepareStart()
 
-	chs := []<-chan *probe.Tick{}
-	for _, p := range s.registry {
-		chs = append(chs, p.Start())
-	}
-
-	s.mergeChannels(chs)
+	s.mergeChannels(s.startProbes())
 	s.subscriberWG.Go(func() {
 		s.sendToSubscribers()
 	})
@@ -153,6 +148,26 @@ func (s *Service) subscribe(kind string, names ...string) *subscriber.Subscriber
 	s.subscriptions[kind] = sub
 	s.subscribers = append(s.subscribers, sub)
 	return sub
+}
+
+func (s *Service) startProbes() []<-chan *probe.Tick {
+	chs := make([]<-chan *probe.Tick, len(s.registry))
+
+	var wg sync.WaitGroup
+	i := 0
+	for _, p := range s.registry {
+		startProbe(&wg, chs, i, p)
+		i++
+	}
+	wg.Wait()
+
+	return chs
+}
+
+func startProbe(wg *sync.WaitGroup, chs []<-chan *probe.Tick, i int, p *probe.Probe) {
+	wg.Go(func() {
+		chs[i] = p.Start()
+	})
 }
 
 func (s *Service) mergeChannels(chs []<-chan *probe.Tick) {

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -1,6 +1,8 @@
 package server_test
 
 import (
+	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -42,4 +44,74 @@ func TestServiceObserveRejectsUnknownProbes(t *testing.T) {
 
 	_, err = s.Observer("livez")
 	require.ErrorIs(t, err, server.ErrObserverNotFound)
+}
+
+func TestServiceStartRunsInitialChecksConcurrently(t *testing.T) {
+	s := server.NewService()
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+
+	first := &blockingStartChecker{started: make(chan struct{}), release: release}
+	second := &blockingStartChecker{started: make(chan struct{}), release: release}
+
+	s.Register(
+		server.NewRegistration("first", time.Hour, first),
+		server.NewRegistration("second", time.Hour, second),
+	)
+
+	started := make(chan struct{})
+	defer func() {
+		releaseOnce.Do(func() {
+			close(release)
+		})
+
+		select {
+		case <-started:
+			s.Stop()
+		case <-time.After(time.Second):
+			require.Fail(t, "service did not finish starting")
+		}
+	}()
+
+	go func() {
+		s.Start()
+		close(started)
+	}()
+
+	require.Eventually(t, func() bool {
+		return channelClosed(first.started) && channelClosed(second.started)
+	}, time.Second, 10*time.Millisecond)
+
+	releaseOnce.Do(func() {
+		close(release)
+	})
+
+	require.Eventually(t, func() bool {
+		return channelClosed(started)
+	}, time.Second, 10*time.Millisecond)
+}
+
+type blockingStartChecker struct {
+	started chan struct{}
+	release <-chan struct{}
+}
+
+func (c *blockingStartChecker) Check(ctx context.Context) error {
+	close(c.started)
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.release:
+		return nil
+	}
+}
+
+func channelClosed(ch <-chan struct{}) bool {
+	select {
+	case <-ch:
+		return true
+	default:
+		return false
+	}
 }


### PR DESCRIPTION
## What

- Start registered probes concurrently during service startup.
- Preserve the existing contract that startup waits for every initial probe check.
- Add regression coverage proving multiple blocking initial checks begin before either is released.

## Why

- Service startup latency should be bounded by the slowest initial check rather than the sum of all initial checks.

## Testing

- `go test ./server`
- `go test -race ./server`
- `make lint` (passes with existing `gomodguard` deprecation warning)

AI-assisted-by: [Codex](https://openai.com/codex/)
