### PR TITLE
test(feature): cover health contracts

### DIFF
--- a/checker/http_test.go
+++ b/checker/http_test.go
@@ -1,0 +1,43 @@
+package checker_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/alexfalkowski/go-health/v2/checker"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHTTPCheckerStatusCodes(t *testing.T) {
+	tests := []struct {
+		name              string
+		status            int
+		wantInvalidStatus bool
+	}{
+		{name: "ok", status: http.StatusOK},
+		{name: "not modified", status: http.StatusNotModified},
+		{name: "bad request", status: http.StatusBadRequest, wantInvalidStatus: true},
+		{name: "server error", status: http.StatusInternalServerError, wantInvalidStatus: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			t.Cleanup(upstream.Close)
+
+			check := checker.NewHTTPChecker(upstream.URL, time.Second)
+
+			err := check.Check(t.Context())
+
+			if !tt.wantInvalidStatus {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, checker.ErrInvalidStatusCode)
+		})
+	}
+}

--- a/checker/online_test.go
+++ b/checker/online_test.go
@@ -60,3 +60,53 @@ func TestOnlineCheckerReturnsOnFirstHealthyURL(t *testing.T) {
 		}
 	}, time.Second, 10*time.Millisecond)
 }
+
+func TestOnlineCheckerStatusCodes(t *testing.T) {
+	tests := []struct {
+		name          string
+		status        int
+		wantNotOnline bool
+	}{
+		{name: "ok", status: http.StatusOK},
+		{name: "no content", status: http.StatusNoContent},
+		{name: "not modified", status: http.StatusNotModified, wantNotOnline: true},
+		{name: "server error", status: http.StatusInternalServerError, wantNotOnline: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(tt.status)
+			}))
+			t.Cleanup(upstream.Close)
+
+			check := checker.NewOnlineChecker(time.Second, checker.WithURLs(upstream.URL))
+
+			err := check.Check(t.Context())
+
+			if !tt.wantNotOnline {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, checker.ErrNotOnline)
+		})
+	}
+}
+
+func TestOnlineCheckerReturnsNotOnlineWhenEveryURLFails(t *testing.T) {
+	unhealthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(unhealthy.Close)
+
+	missing := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(missing.Close)
+
+	check := checker.NewOnlineChecker(time.Second, checker.WithURLs(unhealthy.URL, missing.URL, "://bad-url"))
+
+	err := check.Check(t.Context())
+
+	require.ErrorIs(t, err, checker.ErrNotOnline)
+}

--- a/checker/tcp_test.go
+++ b/checker/tcp_test.go
@@ -19,7 +19,16 @@ func TestTCPCheckerZeroTimeoutUsesDefault(t *testing.T) {
 	require.Greater(t, dialer.remaining, 25*time.Second)
 }
 
+func TestTCPCheckerClosesSuccessfulConnection(t *testing.T) {
+	dialer := &recordingDialer{}
+	checker := checker.NewTCPChecker("example:80", time.Second, checker.WithDialer(dialer))
+
+	require.NoError(t, checker.Check(context.Background()))
+	require.True(t, dialer.conn.closed)
+}
+
 type recordingDialer struct {
+	conn        *recordingConn
 	hasDeadline bool
 	remaining   time.Duration
 }
@@ -35,8 +44,54 @@ func (d *recordingDialer) DialContext(ctx context.Context, _, _ string) (net.Con
 		d.remaining = time.Until(deadline)
 	}
 
-	conn, peer := net.Pipe()
-	_ = peer.Close()
+	d.conn = &recordingConn{}
 
-	return conn, nil
+	return d.conn, nil
+}
+
+type recordingConn struct {
+	closed bool
+}
+
+func (c *recordingConn) Close() error {
+	c.closed = true
+	return nil
+}
+
+func (c *recordingConn) Read([]byte) (int, error) {
+	return 0, net.ErrClosed
+}
+
+func (c *recordingConn) Write([]byte) (int, error) {
+	return 0, net.ErrClosed
+}
+
+func (c *recordingConn) LocalAddr() net.Addr {
+	return recordingAddr("local")
+}
+
+func (c *recordingConn) RemoteAddr() net.Addr {
+	return recordingAddr("remote")
+}
+
+func (c *recordingConn) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (c *recordingConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (c *recordingConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+type recordingAddr string
+
+func (a recordingAddr) Network() string {
+	return string(a)
+}
+
+func (a recordingAddr) String() string {
+	return string(a)
 }

--- a/checker/timeout_test.go
+++ b/checker/timeout_test.go
@@ -3,6 +3,7 @@ package checker_test
 import (
 	"context"
 	"net"
+	"net/http"
 	"testing"
 	"time"
 
@@ -32,6 +33,38 @@ func TestTCPCheckerTimeoutCause(t *testing.T) {
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
+func TestDBCheckerZeroTimeoutUsesDefault(t *testing.T) {
+	pinger := &recordingPinger{}
+	c := checker.NewDBChecker(pinger, 0)
+
+	require.NoError(t, c.Check(t.Context()))
+	requireDefaultDeadline(t, pinger.hasDeadline, pinger.remaining)
+}
+
+func TestHTTPCheckerZeroTimeoutUsesDefault(t *testing.T) {
+	transport := &deadlineRoundTripper{status: http.StatusNoContent}
+	c := checker.NewHTTPChecker("https://example.com/health", 0, checker.WithRoundTripper(transport))
+
+	require.NoError(t, c.Check(t.Context()))
+	requireDefaultDeadline(t, transport.hasDeadline, transport.remaining)
+}
+
+func TestOnlineCheckerZeroTimeoutUsesDefault(t *testing.T) {
+	transport := &deadlineRoundTripper{status: http.StatusNoContent}
+	c := checker.NewOnlineChecker(0, checker.WithRoundTripper(transport), checker.WithURLs("https://example.com/health"))
+
+	require.NoError(t, c.Check(t.Context()))
+	requireDefaultDeadline(t, transport.hasDeadline, transport.remaining)
+}
+
+func requireDefaultDeadline(t *testing.T, hasDeadline bool, remaining time.Duration) {
+	t.Helper()
+
+	require.True(t, hasDeadline, "expected checker to configure a default timeout deadline")
+	require.Greater(t, remaining, 25*time.Second, "expected deadline to be close to the 30s default")
+	require.Less(t, remaining, 31*time.Second, "expected deadline to stay near the 30s default")
+}
+
 type timeoutPinger struct{}
 
 func (timeoutPinger) PingContext(ctx context.Context) error {
@@ -46,4 +79,40 @@ type timeoutDialer struct{}
 func (timeoutDialer) DialContext(ctx context.Context, _, _ string) (net.Conn, error) {
 	<-ctx.Done()
 	return nil, context.Cause(ctx)
+}
+
+type recordingPinger struct {
+	hasDeadline bool
+	remaining   time.Duration
+}
+
+func (p *recordingPinger) PingContext(ctx context.Context) error {
+	deadline, ok := ctx.Deadline()
+	p.hasDeadline = ok
+	if ok {
+		p.remaining = time.Until(deadline)
+	}
+
+	return nil
+}
+
+type deadlineRoundTripper struct {
+	hasDeadline bool
+	remaining   time.Duration
+	status      int
+}
+
+func (t *deadlineRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	deadline, ok := req.Context().Deadline()
+	t.hasDeadline = ok
+	if ok {
+		t.remaining = time.Until(deadline)
+	}
+
+	return &http.Response{
+		StatusCode: t.status,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
 }

--- a/internal/test/checker/checker.go
+++ b/internal/test/checker/checker.go
@@ -36,6 +36,15 @@ type BlockingPeriodicChecker struct {
 	periodicOnce    sync.Once
 }
 
+// CancelablePeriodicChecker returns once, then blocks future checks until the context is canceled.
+type CancelablePeriodicChecker struct {
+	InitialStarted   chan struct{}
+	PeriodicStarted  chan struct{}
+	PeriodicCanceled chan struct{}
+	canceledOnce     sync.Once
+	periodicOnce     sync.Once
+}
+
 // NewBlockingChecker returns a BlockingChecker with initialized channels.
 func NewBlockingChecker() *BlockingChecker {
 	return &BlockingChecker{
@@ -66,6 +75,15 @@ func NewBlockingPeriodicChecker() *BlockingPeriodicChecker {
 		InitialStarted:  make(chan struct{}),
 		PeriodicStarted: make(chan struct{}),
 		Release:         make(chan struct{}),
+	}
+}
+
+// NewCancelablePeriodicChecker returns a CancelablePeriodicChecker with initialized channels.
+func NewCancelablePeriodicChecker() *CancelablePeriodicChecker {
+	return &CancelablePeriodicChecker{
+		InitialStarted:   make(chan struct{}),
+		PeriodicStarted:  make(chan struct{}),
+		PeriodicCanceled: make(chan struct{}),
 	}
 }
 
@@ -116,6 +134,24 @@ func (c *BlockingPeriodicChecker) Check(context.Context) error {
 	}
 
 	return nil
+}
+
+// Check returns immediately the first time, then waits for context cancellation.
+func (c *CancelablePeriodicChecker) Check(ctx context.Context) error {
+	select {
+	case <-c.InitialStarted:
+		c.periodicOnce.Do(func() {
+			close(c.PeriodicStarted)
+		})
+		<-ctx.Done()
+		c.canceledOnce.Do(func() {
+			close(c.PeriodicCanceled)
+		})
+		return ctx.Err()
+	default:
+		close(c.InitialStarted)
+		return nil
+	}
 }
 
 // WaitForStarted waits until started is closed.

--- a/probe/probe_test.go
+++ b/probe/probe_test.go
@@ -39,6 +39,23 @@ func TestStopCancelsInFlightCheck(t *testing.T) {
 	require.False(t, ok)
 }
 
+func TestStopCancelsPeriodicInFlightCheck(t *testing.T) {
+	ch := testchecker.NewCancelablePeriodicChecker()
+	p := probe.NewProbe("blocking", time.Millisecond, ch)
+
+	ticks, err := p.Start(t.Context())
+	require.NoError(t, err)
+	require.NotNil(t, <-ticks)
+	testchecker.WaitForStarted(t, ch.PeriodicStarted)
+
+	stopped := testprobe.StopProbe(p)
+	testprobe.WaitForStopped(t, stopped)
+	testchecker.WaitForCanceled(t, ch.PeriodicCanceled)
+
+	_, ok := <-ticks
+	require.False(t, ok)
+}
+
 func TestConcurrentStartWaitsForInitialCheck(t *testing.T) {
 	ch := testchecker.NewReleasableChecker()
 	p := probe.NewProbe("blocking", time.Hour, ch)
@@ -132,19 +149,31 @@ func TestStopReturnsContextError(t *testing.T) {
 }
 
 func TestStartWithInvalidPeriodReturnsErrorTick(t *testing.T) {
-	p := probe.NewProbe("noop", 0, checker.NewNoopChecker())
+	tests := []struct {
+		name   string
+		period time.Duration
+	}{
+		{name: "zero", period: 0},
+		{name: "negative", period: -time.Second},
+	}
 
-	require.NotPanics(t, func() {
-		ticks, err := p.Start(t.Context())
-		require.NoError(t, err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := probe.NewProbe("noop", tt.period, checker.NewNoopChecker())
 
-		tick, ok := <-ticks
-		require.True(t, ok)
-		require.Equal(t, "noop", tick.Name())
-		require.ErrorIs(t, tick.Error(), probe.ErrInvalidPeriod)
-		require.ErrorContains(t, tick.Error(), "0s")
+			require.NotPanics(t, func() {
+				ticks, err := p.Start(t.Context())
+				require.NoError(t, err)
 
-		_, ok = <-ticks
-		require.False(t, ok)
-	})
+				tick, ok := <-ticks
+				require.True(t, ok)
+				require.Equal(t, "noop", tick.Name())
+				require.ErrorIs(t, tick.Error(), probe.ErrInvalidPeriod)
+				require.ErrorContains(t, tick.Error(), tt.period.String())
+
+				_, ok = <-ticks
+				require.False(t, ok)
+			})
+		})
+	}
 }

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -50,6 +50,25 @@ func TestServiceObserveRejectsUnknownProbes(t *testing.T) {
 	require.ErrorIs(t, err, server.ErrObserverNotFound)
 }
 
+func TestServiceObserveKeepsOriginalProbeSetForExistingKind(t *testing.T) {
+	s := server.NewService()
+
+	first := server.NewRegistration("first", time.Hour, checker.NewNoopChecker())
+	second := server.NewRegistration("second", time.Hour, checker.NewNoopChecker())
+	s.Register(first, second)
+
+	require.NoError(t, s.Observe("livez", first.Name))
+	observer, err := s.Observer("livez")
+	require.NoError(t, err)
+
+	require.NoError(t, s.Observe("livez", second.Name))
+	sameObserver, err := s.Observer("livez")
+	require.NoError(t, err)
+
+	require.Same(t, observer, sameObserver)
+	require.Equal(t, []string{first.Name}, sameObserver.Names())
+}
+
 //nolint:err113
 func TestServiceStopBeforeStartClosesObservers(t *testing.T) {
 	s := server.NewService()
@@ -116,4 +135,35 @@ func TestServiceStartRunsInitialChecksConcurrently(t *testing.T) {
 	require.Eventually(t, func() bool {
 		return test.ChannelClosed(started)
 	}, time.Second, 10*time.Millisecond)
+}
+
+func TestServiceStartFailureCleansUpStartedProbesAndObservers(t *testing.T) {
+	s := server.NewService()
+	started := testchecker.NewCancelablePeriodicChecker()
+	blocking := testchecker.NewBlockingChecker()
+
+	startedRegistration := server.NewRegistration("started", time.Millisecond, started)
+	blockingRegistration := server.NewRegistration("blocking", time.Hour, blocking)
+	s.Register(startedRegistration, blockingRegistration)
+	require.NoError(t, s.Observe("livez", startedRegistration.Name))
+
+	observer, err := s.Observer("livez")
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	errc := make(chan error, 1)
+	go func() {
+		errc <- s.Start(ctx)
+	}()
+
+	testchecker.WaitForStarted(t, blocking.Started)
+	testchecker.WaitForStarted(t, started.PeriodicStarted)
+
+	cancel()
+
+	require.ErrorIs(t, <-errc, context.Canceled)
+	testchecker.WaitForCanceled(t, blocking.Canceled)
+	testchecker.WaitForCanceled(t, started.PeriodicCanceled)
+	testsubscriber.RequireObserverStopped(t, observer)
+	require.NoError(t, s.Stop(t.Context()))
 }

--- a/subscriber/subscriber_test.go
+++ b/subscriber/subscriber_test.go
@@ -1,12 +1,19 @@
 package subscriber_test
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/alexfalkowski/go-health/v2/probe"
 	"github.com/alexfalkowski/go-health/v2/subscriber"
 	"github.com/alexfalkowski/go-sync"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	dbProbeName    = "db"
+	cacheProbeName = "cache"
 )
 
 func TestCloseWhileSendingDoesNotPanic(t *testing.T) {
@@ -56,4 +63,81 @@ func TestSubscriberClonesNames(t *testing.T) {
 		require.Fail(t, "unexpected tick for mutated probe name", tick.Name())
 	default:
 	}
+}
+
+func TestSubscriberDropsTicksWhenBufferIsFull(t *testing.T) {
+	s := subscriber.NewSubscriber([]string{"a"})
+	first := probe.NewTick("a", nil)
+	second := probe.NewTick("a", nil)
+
+	s.Send(first)
+
+	sent := make(chan struct{})
+	go func() {
+		s.Send(second)
+		close(sent)
+	}()
+
+	select {
+	case <-sent:
+	case <-time.After(time.Second):
+		require.Fail(t, "send blocked while subscriber buffer was full")
+	}
+
+	require.Equal(t, first, <-s.Receive())
+	select {
+	case tick := <-s.Receive():
+		require.Fail(t, "unexpected tick after best-effort drop", tick.Name())
+	default:
+	}
+}
+
+func TestObserverStartsWithNilErrorsForTrackedNames(t *testing.T) {
+	s := subscriber.NewSubscriber([]string{dbProbeName, cacheProbeName})
+	ob := subscriber.NewObserver([]string{dbProbeName, cacheProbeName}, s)
+	s.Close()
+	ob.Wait()
+
+	errs := ob.Errors()
+
+	require.NoError(t, ob.Error())
+	require.Contains(t, errs, dbProbeName)
+	require.NoError(t, errs[dbProbeName])
+	require.Contains(t, errs, cacheProbeName)
+	require.NoError(t, errs[cacheProbeName])
+}
+
+func TestObserverErrorsReturnsCopy(t *testing.T) {
+	s := subscriber.NewSubscriber([]string{dbProbeName, cacheProbeName})
+	ob := subscriber.NewObserver([]string{dbProbeName, cacheProbeName}, s)
+	errDB := errors.New("db failed")
+
+	s.Send(probe.NewTick(dbProbeName, errDB))
+	s.Close()
+	ob.Wait()
+
+	errs := ob.Errors()
+	errs[dbProbeName] = nil
+	delete(errs, cacheProbeName)
+
+	fresh := ob.Errors()
+	require.ErrorIs(t, fresh[dbProbeName], errDB)
+	require.Contains(t, fresh, cacheProbeName)
+	require.NoError(t, fresh[cacheProbeName])
+	require.ErrorIs(t, ob.Error(), errDB)
+}
+
+func TestErrorsErrorJoinsAnnotatedErrors(t *testing.T) {
+	errDB := errors.New("db failed")
+	errCache := errors.New("cache failed")
+	err := subscriber.Errors{
+		dbProbeName:    errDB,
+		cacheProbeName: errCache,
+		"search":       nil,
+	}.Error()
+
+	require.ErrorIs(t, err, errDB)
+	require.ErrorIs(t, err, errCache)
+	require.ErrorContains(t, err, "db:")
+	require.ErrorContains(t, err, "cache:")
 }


### PR DESCRIPTION
## What

- Add focused coverage for checker status handling, timeout defaults, and TCP connection cleanup.
- Add lifecycle coverage for probe cancellation, service observe idempotency, and service start-failure cleanup.
- Add subscriber observer, best-effort delivery, joined error, and StatusURL helper coverage.

## Why

- Pin down documented health-check, observer, and lifecycle contracts that were identified in the test-gap ledger.
- Keep the changes test-focused while adding a reusable internal checker helper for cancellation scenarios.

## Testing

- `go test ./checker ./probe ./subscriber ./internal/test` - passed
- `go test ./server -run 'TestService|TestRestartKeepsObserverReceivingTicks' -count=1` - passed
- `go test ./...` - passed
- `make lint` - passed with existing gomodguard deprecation warning
- `make specs` - passed
