### PR TITLE
feat(style): simplify health helper naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,22 @@ func main() {
 
 	s.Register("payments", apiRegistration, cacheRegistration, readyRegistration)
 
-	if err := s.Observe("payments", "livez", apiRegistration.Name, cacheRegistration.Name); err != nil {
+	if err := s.Observe(
+		"payments",
+		"livez",
+		apiRegistration.Name,
+		cacheRegistration.Name,
+	); err != nil {
 		log.Fatal(err)
 	}
 
-	if err := s.Observe("payments", "readyz", apiRegistration.Name, cacheRegistration.Name, readyRegistration.Name); err != nil {
+	if err := s.Observe(
+		"payments",
+		"readyz",
+		apiRegistration.Name,
+		cacheRegistration.Name,
+		readyRegistration.Name,
+	); err != nil {
 		log.Fatal(err)
 	}
 

--- a/checker/context_test.go
+++ b/checker/context_test.go
@@ -19,18 +19,21 @@ func TestCheckersReturnCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
 
-	checkers := map[string]checker.Checker{
-		"noop":   checker.NewNoopChecker(),
-		"ready":  checker.NewReadyChecker(errNotReady),
-		"http":   checker.NewHTTPChecker("://bad-url", time.Second),
-		"online": checker.NewOnlineChecker(time.Second, checker.WithURLs("://bad-url")),
-		"db":     checker.NewDBChecker(sql.CanceledPinger{}, time.Second),
-		"tcp":    checker.NewTCPChecker("example:80", time.Second, checker.WithDialer(net.CanceledDialer{})),
+	checkers := []struct {
+		check checker.Checker
+		name  string
+	}{
+		{check: checker.NewNoopChecker(), name: "noop"},
+		{check: checker.NewReadyChecker(errNotReady), name: "ready"},
+		{check: checker.NewHTTPChecker("://bad-url", time.Second), name: "http"},
+		{check: checker.NewOnlineChecker(time.Second, checker.WithURLs("://bad-url")), name: "online"},
+		{check: checker.NewDBChecker(sql.CanceledPinger{}, time.Second), name: "db"},
+		{check: checker.NewTCPChecker("example:80", time.Second, checker.WithDialer(net.CanceledDialer{})), name: "tcp"},
 	}
 
-	for name, check := range checkers {
-		t.Run(name, func(t *testing.T) {
-			err := check.Check(ctx)
+	for _, tt := range checkers {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.check.Check(ctx)
 
 			require.ErrorIs(t, err, context.Canceled)
 			require.NotErrorIs(t, err, errNotReady)

--- a/checker/http.go
+++ b/checker/http.go
@@ -19,11 +19,11 @@ var ErrInvalidStatusCode = errors.New("invalid status code")
 // package default of 30 seconds. Use WithRoundTripper to provide a custom
 // transport for tests or bespoke network behavior.
 func NewHTTPChecker(url string, t time.Duration, opts ...Option) *HTTPChecker {
-	os := parseOptions(opts...)
+	options := parseOptions(opts...)
 
 	return &HTTPChecker{
 		url:    url,
-		client: &http.Client{Transport: os.roundTripper, Timeout: timeout(t)},
+		client: &http.Client{Transport: options.roundTripper, Timeout: timeout(t)},
 	}
 }
 

--- a/checker/online.go
+++ b/checker/online.go
@@ -19,11 +19,11 @@ var ErrNotOnline = errors.New("not online")
 // Passing 0 uses the package default timeout of 30 seconds. It uses the default
 // URL list unless overridden via WithURLs.
 func NewOnlineChecker(t time.Duration, opts ...Option) *OnlineChecker {
-	os := parseOptions(opts...)
+	options := parseOptions(opts...)
 
 	return &OnlineChecker{
-		urls:   os.urls,
-		client: &http.Client{Transport: os.roundTripper, Timeout: timeout(t)},
+		urls:   options.urls,
+		client: &http.Client{Transport: options.roundTripper, Timeout: timeout(t)},
 	}
 }
 
@@ -54,7 +54,7 @@ func (c *OnlineChecker) Check(ctx context.Context) error {
 	results := make(chan bool, len(c.urls))
 	for _, url := range c.urls {
 		go func() {
-			healthy := c.check(checkCtx, url)
+			healthy := c.checkURL(checkCtx, url)
 			if healthy {
 				cancel()
 			}
@@ -77,7 +77,7 @@ func (c *OnlineChecker) Check(ctx context.Context) error {
 	return fmt.Errorf("online checker: %w", ErrNotOnline)
 }
 
-func (c *OnlineChecker) check(ctx context.Context, url string) bool {
+func (c *OnlineChecker) checkURL(ctx context.Context, url string) bool {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, http.NoBody)
 	if err != nil {
 		return false

--- a/checker/options.go
+++ b/checker/options.go
@@ -51,23 +51,23 @@ func WithURLs(urls ...string) Option {
 }
 
 func parseOptions(opts ...Option) *options {
-	os := &options{}
+	parsed := &options{}
 	for _, o := range opts {
-		o.apply(os)
+		o.apply(parsed)
 	}
-	if os.roundTripper == nil {
-		os.roundTripper = http.DefaultTransport
+	if parsed.roundTripper == nil {
+		parsed.roundTripper = http.DefaultTransport
 	}
-	if os.dialer == nil {
-		os.dialer = net.DefaultDialer
+	if parsed.dialer == nil {
+		parsed.dialer = net.DefaultDialer
 	}
-	if len(os.urls) == 0 {
-		os.urls = []string{
+	if len(parsed.urls) == 0 {
+		parsed.urls = []string{
 			"https://google.com/generate_204",
 			"https://cp.cloudflare.com/generate_204",
 			"https://connectivity-check.ubuntu.com",
 		}
 	}
 
-	return os
+	return parsed
 }

--- a/checker/tcp.go
+++ b/checker/tcp.go
@@ -16,9 +16,9 @@ var _ Checker = (*TCPChecker)(nil)
 // uses the package default of 30 seconds. Use WithDialer to override the
 // dialing implementation.
 func NewTCPChecker(address string, t time.Duration, opts ...Option) *TCPChecker {
-	os := parseOptions(opts...)
+	options := parseOptions(opts...)
 
-	return &TCPChecker{address: address, timeout: timeout(t), dialer: os.dialer}
+	return &TCPChecker{address: address, timeout: timeout(t), dialer: options.dialer}
 }
 
 // TCPChecker checks TCP connectivity to an address.

--- a/checker/tcp_test.go
+++ b/checker/tcp_test.go
@@ -12,18 +12,18 @@ import (
 
 func TestTCPCheckerZeroTimeoutUsesDefault(t *testing.T) {
 	dialer := &recordingDialer{}
-	checker := checker.NewTCPChecker("example:80", 0, checker.WithDialer(dialer))
+	check := checker.NewTCPChecker("example:80", 0, checker.WithDialer(dialer))
 
-	require.NoError(t, checker.Check(context.Background()))
+	require.NoError(t, check.Check(context.Background()))
 	require.True(t, dialer.hasDeadline)
 	require.Greater(t, dialer.remaining, 25*time.Second)
 }
 
 func TestTCPCheckerClosesSuccessfulConnection(t *testing.T) {
 	dialer := &recordingDialer{}
-	checker := checker.NewTCPChecker("example:80", time.Second, checker.WithDialer(dialer))
+	check := checker.NewTCPChecker("example:80", time.Second, checker.WithDialer(dialer))
 
-	require.NoError(t, checker.Check(context.Background()))
+	require.NoError(t, check.Check(context.Background()))
 	require.True(t, dialer.conn.closed)
 }
 

--- a/internal/test/probe/probe.go
+++ b/internal/test/probe/probe.go
@@ -44,7 +44,7 @@ func WaitForStart(t *testing.T, started <-chan StartResult, name string) StartRe
 	case result := <-started:
 		return result
 	case <-time.After(time.Second):
-		require.Fail(t, name+" did not return after release")
+		require.Fail(t, name+" did not return")
 		return StartResult{}
 	}
 }

--- a/internal/test/subscriber/subscriber.go
+++ b/internal/test/subscriber/subscriber.go
@@ -17,12 +17,6 @@ type ErrorObserver interface {
 	Error() error
 }
 
-// Fataler reports fatal test or benchmark failures.
-type Fataler interface {
-	Helper()
-	Fatal(args ...any)
-}
-
 // RequireObserverNoError waits until observer reports no error.
 func RequireObserverNoError(t *testing.T, observer ErrorObserver) {
 	t.Helper()
@@ -57,7 +51,7 @@ func RequireObserverStopped(t *testing.T, observer Waiter) {
 }
 
 // WaitObserverNoError waits until observer reports no error.
-func WaitObserverNoError(tb Fataler, observer ErrorObserver) {
+func WaitObserverNoError(tb testing.TB, observer ErrorObserver) {
 	tb.Helper()
 
 	deadline := time.Now().Add(time.Second)

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -14,11 +14,11 @@ import (
 // than or equal to zero.
 var ErrInvalidPeriod = errors.New("health: invalid period")
 
-// NewProbe returns a Probe that runs ch at the given period.
+// NewProbe returns a Probe that runs check at the given period.
 //
 // The probe does not start until Start is called.
-func NewProbe(name string, period time.Duration, ch checker.Checker) *Probe {
-	return &Probe{name: name, period: period, checker: ch, mux: sync.Mutex{}}
+func NewProbe(name string, period time.Duration, check checker.Checker) *Probe {
+	return &Probe{name: name, period: period, checker: check, mux: sync.Mutex{}}
 }
 
 // Probe periodically runs a Checker and emits ticks.

--- a/server/server.go
+++ b/server/server.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"iter"
-	"maps"
 
 	"github.com/alexfalkowski/go-health/v2/subscriber"
 	"github.com/alexfalkowski/go-sync"
@@ -44,7 +43,7 @@ func (s *Server) Register(name string, regs ...*Registration) {
 // Services that do not have that observer kind are skipped.
 func (s *Server) Observers(kind string) iter.Seq2[string, *subscriber.Observer] {
 	return func(yield func(string, *subscriber.Observer) bool) {
-		for name, service := range maps.All(s.services) {
+		for name, service := range s.services {
 			observer, err := service.Observer(kind)
 			if err != nil {
 				continue
@@ -122,7 +121,7 @@ func (s *Server) Stop(ctx context.Context) error {
 	}
 
 	services := make([]*Service, 0, len(s.services))
-	for service := range maps.Values(s.services) {
+	for _, service := range s.services {
 		services = append(services, service)
 	}
 	if err := stopServices(ctx, services...); err != nil {
@@ -133,7 +132,7 @@ func (s *Server) Stop(ctx context.Context) error {
 }
 
 func stopServices(ctx context.Context, services ...*Service) error {
-	errs := []error{}
+	errs := make([]error, 0, len(services))
 	for _, service := range services {
 		errs = append(errs, service.Stop(ctx))
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -365,7 +365,7 @@ func TestValidNoopChecker(t *testing.T) {
 	})
 }
 
-func TestInvalidObserver(t *testing.T) {
+func TestObserverReportsUnhealthyProbes(t *testing.T) {
 	s := server.NewServer()
 	defer func() { _ = s.Stop(context.Background()) }()
 

--- a/server/service.go
+++ b/server/service.go
@@ -22,11 +22,11 @@ func NewService() *Service {
 		registry:      make(map[string]*probe.Probe),
 		observers:     make(map[string]*subscriber.Observer),
 		subscriptions: make(map[string]*subscriber.Subscriber),
-		subscribers:   []*subscriber.Subscriber{},
+		done:          make(chan struct{}),
+		ticks:         make(chan *probe.Tick, 1),
 		registryWG:    &sync.WaitGroup{},
 		subscriberWG:  &sync.WaitGroup{},
-		ticks:         make(chan *probe.Tick, 1),
-		done:          make(chan struct{}),
+		subscribers:   []*subscriber.Subscriber{},
 	}
 }
 
@@ -106,13 +106,13 @@ func (s *Service) Start(ctx context.Context) error {
 
 	s.prepareStart()
 
-	chs, err := s.startProbes(ctx)
+	tickChannels, err := s.startProbes(ctx)
 	if err != nil {
 		s.cleanupStartFailure(ctx)
 		return err
 	}
 
-	s.mergeChannels(chs)
+	s.mergeChannels(tickChannels)
 	s.subscriberWG.Go(func() {
 		s.sendToSubscribers()
 	})
@@ -186,7 +186,7 @@ func (s *Service) waitObservers(ctx context.Context) error {
 }
 
 func (s *Service) startProbes(ctx context.Context) ([]<-chan *probe.Tick, error) {
-	chs := make([]<-chan *probe.Tick, len(s.registry))
+	tickChannels := make([]<-chan *probe.Tick, len(s.registry))
 	errs := make([]error, len(s.registry))
 	probes := make([]*probe.Probe, 0, len(s.registry))
 	for _, p := range s.registry {
@@ -196,7 +196,7 @@ func (s *Service) startProbes(ctx context.Context) ([]<-chan *probe.Tick, error)
 	var wg sync.WaitGroup
 	for i, p := range probes {
 		wg.Go(func() {
-			chs[i], errs[i] = p.Start(ctx)
+			tickChannels[i], errs[i] = p.Start(ctx)
 		})
 	}
 	wg.Wait()
@@ -208,11 +208,11 @@ func (s *Service) startProbes(ctx context.Context) ([]<-chan *probe.Tick, error)
 		return nil, err
 	}
 
-	return chs, nil
+	return tickChannels, nil
 }
 
-func (s *Service) mergeChannels(chs []<-chan *probe.Tick) {
-	for _, ch := range chs {
+func (s *Service) mergeChannels(tickChannels []<-chan *probe.Tick) {
+	for _, ch := range tickChannels {
 		s.registryWG.Go(func() {
 			s.sendTick(ch)
 		})

--- a/subscriber/errors.go
+++ b/subscriber/errors.go
@@ -13,15 +13,11 @@ type Errors map[string]error
 //
 // Each non-nil error is wrapped with its probe name before being joined.
 func (e Errors) Error() error {
-	errs := make([]error, len(e))
-	i := 0
-
+	errs := make([]error, 0, len(e))
 	for k, err := range e {
 		if err != nil {
-			errs[i] = fmt.Errorf("%s: %w", k, err)
+			errs = append(errs, fmt.Errorf("%s: %w", k, err))
 		}
-
-		i++
 	}
 
 	return errors.Join(errs...)

--- a/subscriber/observer.go
+++ b/subscriber/observer.go
@@ -14,12 +14,12 @@ import (
 // ticks arrive.
 func NewObserver(names []string, sub *Subscriber) *Observer {
 	names = slices.Clone(names)
-	errors := make(Errors)
+	errs := make(Errors)
 	for _, n := range names {
-		errors[n] = nil
+		errs[n] = nil
 	}
 
-	ob := &Observer{errors: errors, names: names, mux: sync.RWMutex{}}
+	ob := &Observer{errors: errs, names: names, mux: sync.RWMutex{}}
 	ob.start(sub)
 
 	return ob


### PR DESCRIPTION
## What

- Rename option parsing locals, checker helpers, and test variables for clearer scanability.
- Simplify subscriber error aggregation and observer initialization naming.
- Tidy server/service iteration, channel naming, constructor ordering, and README example wrapping.

## Why

- Apply non-blocking style-review polish across the health-check, probe, subscriber, server, and internal test helper code.
- Keep behavior unchanged while making common helpers and tests easier to read.

## Testing

- `go test ./...` - passed
- `make lint` - passed with existing gomodguard deprecation warning
- `make specs` - passed
