### PR TITLE
docs(readme): clarify health monitoring behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/alexfalkowski/go-health/v2.svg)](https://pkg.go.dev/github.com/alexfalkowski/go-health/v2)
 [![Stability: Active](https://masterminds.github.io/stability/active.svg)](https://masterminds.github.io/stability/active.html)
 
-# Health Monitoring Pattern
+# 🩺 Health Monitoring Pattern
 
 `go-health` is a small Go library for building asynchronous health monitoring.
 It separates the problem into four layers:
@@ -19,7 +19,7 @@ This keeps the pieces reusable. You can use a single checker directly, wire
 your own probe loop, or use the `server` package for a complete "register,
 observe, start, stop" workflow.
 
-## Why this library
+## 🎯 Why this library
 
 This repository focuses on a few constraints:
 
@@ -34,7 +34,7 @@ Related background:
 - [Kubernetes liveness and readiness probes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)
 - [Health Check API pattern](https://microservices.io/patterns/observability/health-check-api.html)
 
-## Installation
+## 📦 Installation
 
 ```sh
 go get github.com/alexfalkowski/go-health/v2
@@ -46,32 +46,64 @@ The module path includes `/v2`:
 import "github.com/alexfalkowski/go-health/v2/server"
 ```
 
-## Package overview
+## 🧭 Package overview
 
 | Package | Purpose |
 | --- | --- |
 | `checker` | Reusable health checks for HTTP, TCP, SQL ping, online connectivity, readiness gates, and no-op checks. |
 | `probe` | Periodically runs a checker and emits ticks. |
-| `subscriber` | Tracks the latest error for a selected set of probe names. |
+| `subscriber` | Best-effort tick fan-out and latest-error tracking for selected probe names. |
 | `server` | Registers probes per service, creates observers, and manages lifecycle. |
 | `net` | Small interfaces used to customize network dialing. |
 | `sql` | Small interfaces used to customize database pinging. |
 
-## Key behaviors
+## 🔑 Key behaviors
+
+### ⏱️ Probe and server lifecycle
 
 - `probe.Start` performs an immediate check before the periodic loop continues.
+- `probe.Start` is idempotent while running.
+- `probe.Stop` is safe before start, safe to call multiple times, cancels
+  in-flight checks, and waits for the probe worker to exit.
+- `server.Start` waits for each service's initial checks before returning.
+- `server.Start` and `server.Stop` are idempotent.
+- Call `Stop` after `Start` returns, typically during process shutdown.
+- A probe with an invalid period emits a single error tick and closes.
+
+### 🧩 Registration and observers
+
 - `server.Register` and `server.Observe` are setup-time calls; finish
   registration before calling `Start`.
-- `server.Start` waits for each service's initial checks before returning; call
-  `Stop` after `Start` returns, typically during process shutdown.
-- A probe with an invalid period emits a single error tick and closes.
-- `HTTPChecker`, `TCPChecker`, `DBChecker`, and `OnlineChecker` use a default timeout of `30s` when you pass `0`.
-- `DBChecker` and `TCPChecker` use `checker.ErrTimeout` as the timeout cause for their derived per-call contexts.
-- `OnlineChecker` reports healthy if any configured URL returns `200 OK` or `204 No Content`.
-- `subscriber.Observer` starts with `nil` errors for every tracked probe name and updates as ticks arrive.
-- `server.Service` and `server.Server` keep observer instances across stop/start cycles, so existing observers continue receiving ticks after a restart.
+- `server.Register` replaces an existing service with the same name.
+- Duplicate probe names within a service replace earlier registrations.
+- `server.NewOnlineRegistration` builds a registration named `online`; use
+  `server.NewRegistration` with `checker.NewOnlineChecker` if you need another
+  probe name.
+- `subscriber.Subscriber` sends ticks on a best-effort, non-blocking channel; a
+  slow observer can miss intermediate ticks.
+- `subscriber.Observer` starts with `nil` errors for every tracked probe name
+  and updates as ticks arrive.
+- `server.Service` and `server.Server` keep observer instances across
+  stop/start cycles, so existing observers continue receiving ticks after a
+  restart.
 
-## End-to-end example
+### ✅ Checker defaults
+
+- `HTTPChecker`, `TCPChecker`, `DBChecker`, and `OnlineChecker` use a default
+  timeout of `30s` when you pass `0`.
+- All exported checker implementations are safe for concurrent use.
+- If you inject a shared transport, dialer, or pinger, that dependency should
+  also be safe for the concurrent calls you expect.
+- `HTTPChecker` treats HTTP status codes below `400` as healthy and wraps
+  `checker.ErrInvalidStatusCode` for `4xx` and `5xx` responses.
+- `DBChecker` and `TCPChecker` use `checker.ErrTimeout` as the timeout cause for
+  their derived per-call contexts.
+- `OnlineChecker` reports healthy if any configured URL returns `200 OK` or
+  `204 No Content`.
+- `ReadyChecker.Ready` is a one-way transition; once ready, that checker stays
+  healthy.
+
+## 🚦 End-to-end example
 
 The `server` package is the usual entry point when you want one or more health
 views for a service:
@@ -162,15 +194,17 @@ func main() {
 }
 ```
 
-Notes:
+> [!NOTE]
+> - `Observe` validates that the service exists and every named probe was registered.
+> - The first meaningful observer state arrives after the initial probe tick is processed.
+> - Calling `Observe` again with the same service and kind is a no-op; it does not replace the existing observer.
 
-- `Observe` validates that the service exists and every named probe was registered.
-- The first meaningful observer state arrives after the initial probe tick is processed.
-- Calling `Observe` again with the same service and kind is a no-op; it does not replace the existing observer.
+## 🧪 Direct checker examples
 
-## Direct checker examples
+### 🌐 HTTP checker
 
-### HTTP checker
+`HTTPChecker` performs a `GET` request. Redirects and other status codes below
+`400` are considered healthy; `4xx` and `5xx` responses are unhealthy.
 
 ```go
 check := checker.NewHTTPChecker("https://example.com/health", 5*time.Second)
@@ -191,10 +225,18 @@ check := checker.NewHTTPChecker(
 )
 ```
 
-### Online checker
+### 🌍 Online checker
 
 `OnlineChecker` is useful when the question is "can this process reach the
 outside world?" rather than "is this exact upstream healthy?"
+
+By default it checks:
+
+- `https://google.com/generate_204`
+- `https://cp.cloudflare.com/generate_204`
+- `https://connectivity-check.ubuntu.com`
+
+Use `checker.WithURLs` to replace that default list:
 
 ```go
 check := checker.NewOnlineChecker(
@@ -210,7 +252,22 @@ if err := check.Check(context.Background()); err != nil {
 }
 ```
 
-### Readiness gate
+### 🗄️ Database checker
+
+`DBChecker` depends on the small `sql.Pinger` interface. A standard
+`*database/sql.DB` satisfies that interface, so you can use it directly:
+
+```go
+var db *sql.DB
+
+check := checker.NewDBChecker(db, 5*time.Second)
+
+if err := check.Check(context.Background()); err != nil {
+	log.Printf("database unhealthy: %v", err)
+}
+```
+
+### 🚪 Readiness gate
 
 `ReadyChecker` lets your application control readiness explicitly:
 
@@ -225,7 +282,7 @@ if err := ready.Check(context.Background()); err != nil {
 ready.Ready()
 ```
 
-## Manual probe usage
+## ⏱️ Manual probe usage
 
 If you do not need the `server` package, you can work directly with a probe:
 
@@ -241,7 +298,10 @@ tick := <-ticks
 log.Printf("%s healthy=%t", tick.Name(), tick.Error() == nil)
 ```
 
-## Working with observers
+`Stop` cancels any check still running and waits for the probe goroutine to
+exit, or returns the supplied context error if that wait is canceled.
+
+## 👀 Working with observers
 
 Observers give you both a summary and a detailed view:
 
@@ -253,7 +313,16 @@ details := observer.Errors() // copy of the latest per-probe error map
 `Errors()` returns a copy, so callers can inspect or mutate the returned map
 without affecting the observer's internal state.
 
-## Development
+When you manage multiple services, `Server.Observers(kind)` iterates the
+services that have that observer kind and skips services that do not:
+
+```go
+for name, observer := range s.Observers("readyz") {
+	log.Printf("%s ready=%t", name, observer.Error() == nil)
+}
+```
+
+## 🛠️ Development
 
 This repository uses a `bin/` git submodule for shared build tooling. Before
 running the `make` targets, initialize the submodule:
@@ -279,7 +348,7 @@ Local test notes:
 - Some tests expect a local status service on `STATUS_PORT`, defaulting to `6000`.
 - CircleCI starts `alexfalkowski/status:latest` for that service during CI.
 
-## Documentation
+## 📚 Documentation
 
 - Package documentation lives in `doc.go` files and exported symbol comments.
 - Runnable pkg.go.dev examples live in `example_test.go` files.


### PR DESCRIPTION
## What

- Add emoji markers to each README heading for faster visual scanning.
- Document missing health monitoring behaviors around probe and server lifecycle idempotency, checker concurrency, subscriber best-effort delivery, HTTP status handling, online checker defaults, online registration naming, and readiness transitions.
- Add README examples for database checks and iterating observers across services.

## Why

- Keeps user-facing documentation aligned with the public API and package docs so users can reason about asynchronous health state, default network behavior, and lifecycle expectations without reading source.
- Makes the README easier to scan while preserving the existing package-focused structure.

## Testing

- `git diff --check -- README.md` - passed
- `rg '^#{1,6} ' README.md` - passed
- Full Go tests were not run because this is a README-only documentation change.
