### PR TITLE
feat(sync): simplify lifecycle error collection

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -132,10 +132,12 @@ func (s *Server) Stop(ctx context.Context) error {
 }
 
 func stopServices(ctx context.Context, services ...*Service) error {
-	errs := make([]error, 0, len(services))
+	var g sync.ErrorsGroup
 	for _, service := range services {
-		errs = append(errs, service.Stop(ctx))
+		g.Go(func() error {
+			return service.Stop(ctx)
+		})
 	}
 
-	return errors.Join(errs...)
+	return g.Wait()
 }

--- a/server/service.go
+++ b/server/service.go
@@ -187,21 +187,21 @@ func (s *Service) waitObservers(ctx context.Context) error {
 
 func (s *Service) startProbes(ctx context.Context) ([]<-chan *probe.Tick, error) {
 	tickChannels := make([]<-chan *probe.Tick, len(s.registry))
-	errs := make([]error, len(s.registry))
 	probes := make([]*probe.Probe, 0, len(s.registry))
 	for _, p := range s.registry {
 		probes = append(probes, p)
 	}
 
-	var wg sync.WaitGroup
+	var g sync.ErrorsGroup
 	for i, p := range probes {
-		wg.Go(func() {
-			tickChannels[i], errs[i] = p.Start(ctx)
+		g.Go(func() error {
+			ch, err := p.Start(ctx)
+			tickChannels[i] = ch
+			return err
 		})
 	}
-	wg.Wait()
 
-	if err := errors.Join(errs...); err != nil {
+	if err := g.Wait(); err != nil {
 		if stopErr := s.stopProbes(context.WithoutCancel(ctx)); stopErr != nil {
 			return nil, errors.Join(err, stopErr)
 		}
@@ -246,23 +246,14 @@ func (s *Service) cleanupStartFailure(ctx context.Context) {
 }
 
 func (s *Service) stopProbes(ctx context.Context) error {
-	errs := make([]error, 0, len(s.registry))
-	errc := make(chan error, len(s.registry))
-
-	var wg sync.WaitGroup
+	var g sync.ErrorsGroup
 	for _, p := range s.registry {
-		wg.Go(func() {
-			errc <- p.Stop(ctx)
+		g.Go(func() error {
+			return p.Stop(ctx)
 		})
 	}
-	wg.Wait()
-	close(errc)
 
-	for err := range errc {
-		errs = append(errs, err)
-	}
-
-	return errors.Join(errs...)
+	return g.Wait()
 }
 
 func (s *Service) validateProbeNames(names ...string) error {


### PR DESCRIPTION
## What

- Use `sync.ErrorsGroup` for concurrent server lifecycle error aggregation.
- Apply it to service probe startup, service probe shutdown, and server-wide service shutdown.
- Preserve joined-error reporting while removing manual error slices and channels.

## Why

- Keeps concurrent health lifecycle code aligned with the shared `go-sync` helper that records every returned error.
- Starts independent service shutdown work promptly instead of letting one service consume the shared stop context before later services are asked to stop.

## Testing

- `go test ./server -run 'TestService|TestRestartKeepsObserverReceivingTicks|TestStartReturnsServiceStartError|TestStopReturnsContextError|TestInvalidPeriod' -count=1` - passed
- `make lint` - passed with the existing `gomodguard` deprecation warning and `0 issues`.
- Full `make specs` was not run locally; CI will run the full status-service-backed suite.

AI-assisted-by: [Codex](https://openai.com/codex/)
