### PR TITLE
docs(readme): clarify health-check contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,10 @@ Local test notes:
 - Some tests make real network calls.
 - Some tests expect a local status service on `STATUS_PORT`, defaulting to `6000`.
 - CircleCI starts `alexfalkowski/status:latest` for that service during CI.
+- For local `make specs` runs that need the status service, run `make start`
+  before the tests and `make stop` afterward. These commands use the shared
+  `bin/` Docker helper, which may require Docker, GitHub SSH access, and a
+  writable sibling `../docker` checkout.
 
 ## 📚 Documentation
 

--- a/checker/doc.go
+++ b/checker/doc.go
@@ -53,5 +53,7 @@
 //
 //	readyChecker.Ready()
 //
-// All exported checker implementations are safe for concurrent use.
+// All exported checker implementations are safe for concurrent use when their
+// injected transport, dialer, or pinger is safe for the concurrent calls the
+// checker may make.
 package checker

--- a/checker/noop.go
+++ b/checker/noop.go
@@ -12,7 +12,7 @@ func NewNoopChecker() *NoopChecker {
 	return &NoopChecker{}
 }
 
-// NoopChecker is a Checker that always returns nil.
+// NoopChecker reports healthy unless the supplied context is canceled.
 type NoopChecker struct{}
 
 // Check always returns nil unless ctx is canceled.

--- a/checker/ready.go
+++ b/checker/ready.go
@@ -12,12 +12,16 @@ var _ Checker = (*ReadyChecker)(nil)
 //
 // Until Ready is called, Check returns err. Callers typically pass a stable
 // sentinel error such as errors.New("not ready") so they can detect the reason
-// with errors.Is.
+// with errors.Is. Passing nil makes the checker report healthy before Ready is
+// called.
 func NewReadyChecker(err error) *ReadyChecker {
 	return &ReadyChecker{err: err}
 }
 
 // ReadyChecker reports a fixed error until it is marked ready.
+//
+// If the configured error is nil, Check reports healthy even before Ready is
+// called.
 //
 // Ready is a one-way transition; once marked ready the checker stays healthy for
 // the lifetime of the value.

--- a/internal/test/test.go
+++ b/internal/test/test.go
@@ -8,6 +8,9 @@ import (
 )
 
 // StatusURL returns the URL for the local status test service.
+//
+// It reads STATUS_PORT and falls back to 6000, producing URLs in the form
+// http://localhost:<port>/v1/status/<status>.
 func StatusURL(status string) string {
 	port := cmp.Or(os.Getenv("STATUS_PORT"), "6000")
 	return fmt.Sprintf("http://localhost:%s/v1/status/%s", port, status)

--- a/probe/doc.go
+++ b/probe/doc.go
@@ -16,16 +16,20 @@
 //
 // # Scheduling behavior
 //
-// Start performs an initial check with the supplied context before returning the
-// channel, then continues on the configured period until Stop is called. If the
-// period is zero or negative, Start returns a closed channel after emitting a
-// single tick whose error wraps ErrInvalidPeriod.
+// Start uses the supplied context for startup and the initial check before
+// returning the channel, then continues on the configured period until Stop is
+// called. If the context is canceled before startup completes, Start returns the
+// context error and no tick channel. Canceling that context after Start returns
+// does not stop the probe; use Stop to end the probe lifecycle. If the period is
+// zero or negative, Start returns a closed channel after emitting a single tick
+// whose error wraps ErrInvalidPeriod.
 //
 // # Lifecycle
 //
-// Start is idempotent while a probe is running: repeated calls return the same
-// channel. Stop is also idempotent and cancels any in-flight check before waiting
-// for the probe goroutine to exit or the supplied context to expire.
+// Start is idempotent while a probe is running: repeated calls with a live
+// context return the same channel once startup has completed. Stop is also
+// idempotent and cancels any in-flight check before waiting for the probe
+// goroutine to exit or the supplied context to expire.
 //
 // # Example
 //

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -40,8 +40,12 @@ type activeProbe struct {
 
 // Start begins running checks and returns a channel of ticks.
 //
-// Start performs an initial check before returning so callers can observe an
-// immediate result. If the probe is already running, Start returns the existing
+// Start performs an initial check with ctx before returning so callers can
+// observe an immediate result. The context controls startup and the initial
+// readiness wait; if it is canceled before startup completes, Start returns the
+// context error and no tick channel. Canceling ctx after Start returns does not
+// stop the probe; use Stop to end the probe lifecycle. If the probe is already
+// running and ctx remains valid through readiness, Start returns the existing
 // channel.
 func (p *Probe) Start(ctx context.Context) (<-chan *Tick, error) {
 	if err := ctx.Err(); err != nil {

--- a/server/registration.go
+++ b/server/registration.go
@@ -9,7 +9,9 @@ import (
 // NewOnlineRegistration returns a registration for an online checker.
 //
 // The registration name is fixed to "online". If you need a different name, use
-// NewRegistration with checker.NewOnlineChecker directly.
+// NewRegistration with checker.NewOnlineChecker directly. The period must be
+// positive; non-positive periods are reported through observer state as
+// probe.ErrInvalidPeriod after the service starts.
 func NewOnlineRegistration(timeout, period time.Duration, opts ...checker.Option) *Registration {
 	return &Registration{
 		Name:    "online",
@@ -19,6 +21,9 @@ func NewOnlineRegistration(timeout, period time.Duration, opts ...checker.Option
 }
 
 // NewRegistration returns a registration for a checker.
+//
+// The period must be positive. Non-positive periods are reported through probe
+// and observer state as probe.ErrInvalidPeriod after the service starts.
 func NewRegistration(name string, period time.Duration, ch checker.Checker) *Registration {
 	return &Registration{Name: name, Period: period, Checker: ch}
 }
@@ -27,5 +32,6 @@ func NewRegistration(name string, period time.Duration, ch checker.Checker) *Reg
 type Registration struct {
 	Checker checker.Checker
 	Name    string
-	Period  time.Duration
+	// Period is the interval between checks and must be positive.
+	Period time.Duration
 }

--- a/server/server.go
+++ b/server/server.go
@@ -57,6 +57,9 @@ func (s *Server) Observers(kind string) iter.Seq2[string, *subscriber.Observer] 
 }
 
 // Observer returns an observer for the service name and observer kind.
+//
+// It returns ErrServiceNotFound if name has not been registered, or
+// ErrObserverNotFound if the service does not have kind.
 func (s *Server) Observer(name, kind string) (*subscriber.Observer, error) {
 	service, ok := s.services[name]
 	if !ok {
@@ -70,6 +73,8 @@ func (s *Server) Observer(name, kind string) (*subscriber.Observer, error) {
 //
 // Observe is intended for setup before Start. The observer will track the probes
 // listed in names. Repeated calls with the same service and kind are idempotent.
+// It returns ErrServiceNotFound if name has not been registered, or
+// ErrProbeNotFound if any probe name is unknown.
 func (s *Server) Observe(name, kind string, names ...string) error {
 	service, ok := s.services[name]
 	if !ok {
@@ -82,7 +87,9 @@ func (s *Server) Observe(name, kind string, names ...string) error {
 // Start starts all registered services.
 //
 // Start is idempotent. It waits for each service's initial checks before
-// returning; call Stop after Start has returned during normal shutdown.
+// returning; call Stop after Start has returned during normal shutdown. If a
+// service fails to start, Start stops any services started during that attempt,
+// leaves the server stopped, and the server may be started again later.
 func (s *Server) Start(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err

--- a/server/service.go
+++ b/server/service.go
@@ -60,6 +60,8 @@ func (s *Service) Register(regs ...*Registration) {
 }
 
 // Observer returns the observer for kind.
+//
+// It returns ErrObserverNotFound if kind has not been registered.
 func (s *Service) Observer(kind string) (*subscriber.Observer, error) {
 	observer, ok := s.observers[kind]
 	if !ok {
@@ -73,7 +75,8 @@ func (s *Service) Observer(kind string) (*subscriber.Observer, error) {
 //
 // Observe is intended for setup before Start. It returns an error if any probe
 // name has not been registered. Repeated calls with the same kind are idempotent
-// and keep the original probe set.
+// and keep the original probe set. Unknown probe names are reported with
+// ErrProbeNotFound; multiple unknown probes are joined into one error.
 func (s *Service) Observe(kind string, names ...string) error {
 	_, ok := s.observers[kind]
 	if !ok {
@@ -91,7 +94,10 @@ func (s *Service) Observe(kind string, names ...string) error {
 //
 // Existing observers continue receiving updates if the service is stopped and
 // started again later. Start waits for each probe's initial check before
-// returning; call Stop after Start has returned during normal shutdown.
+// returning; call Stop after Start has returned during normal shutdown. If a
+// probe fails to start, Start cleans up partially started probes and
+// subscriptions, leaves the service stopped, and the service may be started
+// again later.
 func (s *Service) Start(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err

--- a/subscriber/doc.go
+++ b/subscriber/doc.go
@@ -3,7 +3,7 @@
 // Subscriber is the transport layer for ticks inside a service: it accepts probe
 // results for a configured set of names and forwards matching ticks to a channel.
 // Observer is the stateful layer on top of that channel: it consumes ticks in a
-// goroutine and remembers the latest error for each tracked probe.
+// goroutine and remembers the latest error for each received probe tick.
 //
 // This package is typically used indirectly through the server package, but the
 // types are also useful when you want to build custom aggregation or expose
@@ -23,7 +23,9 @@
 //
 // Subscriber.Send is best-effort and non-blocking. If the buffer is full, the
 // tick is dropped rather than back-pressuring the producer. This keeps probe
-// execution decoupled from slow observers.
+// execution decoupled from slow observers. Observer trusts its Subscriber for
+// tick filtering, so direct users should construct both with the same probe names
+// when they expect Names and Errors to describe the same set.
 //
 // # Example
 //

--- a/subscriber/observer.go
+++ b/subscriber/observer.go
@@ -11,7 +11,8 @@ import (
 // The observer starts consuming the subscriber immediately in a background
 // goroutine. The names slice is cloned and used to seed the error map with nil
 // values for all tracked probes, so the observer appears healthy until matching
-// ticks arrive.
+// ticks arrive. The observer trusts sub for tick filtering; pass a subscriber
+// configured with the same names when Names and Errors should stay aligned.
 func NewObserver(names []string, sub *Subscriber) *Observer {
 	names = slices.Clone(names)
 	errs := make(Errors)
@@ -25,7 +26,7 @@ func NewObserver(names []string, sub *Subscriber) *Observer {
 	return ob
 }
 
-// Observer maintains the latest health state for a set of probes.
+// Observer maintains the latest health state for probe ticks it receives.
 type Observer struct {
 	errors Errors
 	names  []string
@@ -58,7 +59,10 @@ func (o *Observer) Names() []string {
 
 // Restart waits for the current subscriber to finish and starts observing sub.
 //
-// Existing error state is retained until new ticks arrive.
+// Restart does not close the current subscriber. Callers must close it first so
+// the current observe loop can exit; the replacement subscriber starts only
+// after that channel closes. Existing error state is retained until new ticks
+// arrive.
 func (o *Observer) Restart(sub *Subscriber) {
 	o.wg.Wait()
 	o.start(sub)


### PR DESCRIPTION
## What

- Clarify local status-service setup for status-dependent test runs and document the STATUS_PORT fallback used by the internal helper.
- Tighten public GoDoc for checker, probe, subscriber, and server contracts around cancellation, readiness, observer lifecycle, registration periods, startup cleanup, and sentinel errors.
- Remove the resolved local doc-gap ledger after applying the approved documentation batch.

## Why

- These notes close concrete documentation gaps that could make health-check users or maintainers misread lifecycle behavior, readiness defaults, observer filtering, or local test prerequisites.
- The change keeps public documentation aligned with tested behavior without changing runtime APIs or implementation behavior.

## Testing

- `git diff --check` - passed
- `make -n start` - passed
- `make -n stop` - passed
- `make -n specs` - passed
- `go test ./internal/test/... ./checker ./probe ./subscriber -count=1` - passed
- `go test ./server -run 'ExampleNewServer|TestInvalidPeriod|TestStartReturnsServiceStartError|TestServiceStartFailureCleansUpStartedProbesAndObservers|TestObserveUnknownProbeNames|TestInvalidObservers|TestServiceObserveRejectsUnknownProbes|TestRestartKeepsObserverReceivingTicks' -count=1` - passed
- `make lint` - passed with the existing gomodguard deprecation warning from golangci-lint
- `go doc ./checker`, `go doc ./probe`, `go doc ./subscriber`, `go doc ./server`, and `go doc ./internal/test` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
