### PR TITLE
docs(readme): clarify health lifecycle contracts

### DIFF
--- a/checker/doc.go
+++ b/checker/doc.go
@@ -16,7 +16,8 @@
 //   - OnlineChecker for best-effort external connectivity checks across a list
 //     of URLs.
 //   - ReadyChecker for application-managed readiness gates.
-//   - NoopChecker for always-healthy checks.
+//   - NoopChecker for checks that only fail when the supplied context is
+//     canceled.
 //
 // # Timeouts and defaults
 //

--- a/checker/noop.go
+++ b/checker/noop.go
@@ -4,10 +4,11 @@ import "context"
 
 var _ Checker = (*NoopChecker)(nil)
 
-// NewNoopChecker returns a Checker that always reports healthy.
+// NewNoopChecker returns a Checker that reports healthy unless the context
+// passed to Check is canceled.
 //
 // It is useful in tests, examples, or when a health group needs a placeholder
-// dependency that should never fail.
+// dependency that should have no dependency-specific failure mode.
 func NewNoopChecker() *NoopChecker {
 	return &NoopChecker{}
 }

--- a/probe/doc.go
+++ b/probe/doc.go
@@ -19,10 +19,12 @@
 // Start uses the supplied context for startup and the initial check before
 // returning the channel, then continues on the configured period until Stop is
 // called. If the context is canceled before startup completes, Start returns the
-// context error and no tick channel. Canceling that context after Start returns
-// does not stop the probe; use Stop to end the probe lifecycle. If the period is
-// zero or negative, Start returns a closed channel after emitting a single tick
-// whose error wraps ErrInvalidPeriod.
+// context error and no tick channel. If Stop cancels startup before the initial
+// result can be emitted, Start can return nil error with a closed tick channel
+// and no initial tick. Canceling that context after Start returns does not stop
+// the probe; use Stop to end the probe lifecycle. If the period is zero or
+// negative, Start returns a closed channel after emitting a single tick whose
+// error wraps ErrInvalidPeriod.
 //
 // # Lifecycle
 //

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -43,10 +43,11 @@ type activeProbe struct {
 // Start performs an initial check with ctx before returning so callers can
 // observe an immediate result. The context controls startup and the initial
 // readiness wait; if it is canceled before startup completes, Start returns the
-// context error and no tick channel. Canceling ctx after Start returns does not
-// stop the probe; use Stop to end the probe lifecycle. If the probe is already
-// running and ctx remains valid through readiness, Start returns the existing
-// channel.
+// context error and no tick channel. If Stop cancels startup before the initial
+// result can be emitted, Start can return nil error with a closed tick channel
+// and no initial tick. Canceling ctx after Start returns does not stop the
+// probe; use Stop to end the probe lifecycle. If the probe is already running
+// and ctx remains valid through readiness, Start returns the existing channel.
 func (p *Probe) Start(ctx context.Context) (<-chan *Tick, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err

--- a/server/service.go
+++ b/server/service.go
@@ -33,9 +33,9 @@ func NewService() *Service {
 // Service maintains probes, subscribers, and observers for a single service.
 //
 // Register and Observe are setup-time calls. Start begins running all probes,
-// waits for their initial checks, and fan-outs their ticks to subscribers. Stop
-// tears everything down after Start has returned and preserves observers so the
-// service can be started again later.
+// waits for their initial checks, and fan-outs their ticks to subscribers. Start
+// and Stop are idempotent. Stop is safe before Start and preserves observers so
+// the service can be started again later with the same observer instances.
 type Service struct {
 	registry      map[string]*probe.Probe
 	observers     map[string]*subscriber.Observer
@@ -94,10 +94,10 @@ func (s *Service) Observe(kind string, names ...string) error {
 //
 // Existing observers continue receiving updates if the service is stopped and
 // started again later. Start waits for each probe's initial check before
-// returning; call Stop after Start has returned during normal shutdown. If a
-// probe fails to start, Start cleans up partially started probes and
-// subscriptions, leaves the service stopped, and the service may be started
-// again later.
+// returning. Repeated calls while the service is running are no-ops. Call Stop
+// after Start has returned during normal shutdown. If a probe fails to start,
+// Start cleans up partially started probes and subscriptions, leaves the service
+// stopped, and the service may be started again later.
 func (s *Service) Start(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -129,7 +129,10 @@ func (s *Service) Start(ctx context.Context) error {
 
 // Stop stops all probes and closes all subscribers.
 //
-// Stop waits for in-flight fan-in and fan-out work to finish before returning.
+// Stop is safe before Start and safe to call multiple times. It waits for
+// in-flight fan-in and fan-out work to finish before returning. Observer
+// instances are preserved; if the service is started again later, those
+// observers are attached to fresh subscribers.
 func (s *Service) Stop(ctx context.Context) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()


### PR DESCRIPTION
## What

- Clarify that NoopChecker still returns context cancellation errors instead of describing it as unconditionally healthy.
- Document the probe startup race where Stop can close the returned tick channel before an initial tick is emitted.
- Document direct Service lifecycle idempotence, Stop-before-Start behavior, and observer preservation across restarts.

## Why

- These comments describe public API contracts that are easy to misuse when callers manage health checks, probes, or services directly.
- The updates align GoDoc with existing tests for cancellation, startup shutdown races, and restart-safe observers.

## Testing

- `go test ./checker -run TestCheckersReturnCanceledContext -count=1` - passed
- `go test ./probe -run 'TestStopCancelsInFlightCheck|ExampleNewProbe' -count=1` - passed
- `go test ./server -run 'TestService(StartStopGuards|StopBeforeStartClosesObservers)' -count=1` - passed
- `make lint` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
