### PR TITLE
docs(readme): clarify health check lifecycle contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,15 @@ import "github.com/alexfalkowski/go-health/v2/server"
 
 - `probe.Start` performs an immediate check before the periodic loop continues.
 - `probe.Start` is idempotent while running.
-- `probe.Stop` is safe before start, safe to call multiple times, cancels
-  in-flight checks, and waits for the probe worker to exit.
+- `probe.Stop` is safe before start, safe to call multiple times, cancels the
+  context for in-flight checks, and waits for the probe worker to exit.
 - `server.Start` waits for each service's initial checks before returning.
+  Observer state is updated asynchronously after those probe ticks are fanned
+  out.
 - `server.Start` and `server.Stop` are idempotent.
 - Call `Stop` after `Start` returns, typically during process shutdown.
+- If `Stop` returns the supplied context error, shutdown work did not finish
+  and should be retried or handled as incomplete cleanup.
 - A probe with an invalid period emits a single error tick and closes.
 
 ### 🧩 Registration and observers
@@ -94,6 +98,8 @@ import "github.com/alexfalkowski/go-health/v2/server"
 - All exported checker implementations are safe for concurrent use.
 - If you inject a shared transport, dialer, or pinger, that dependency should
   also be safe for the concurrent calls you expect.
+- Custom checkers shared across registrations should also be safe for
+  concurrent `Check` calls; service startup starts probes concurrently.
 - `HTTPChecker` treats HTTP status codes below `400` as healthy and wraps
   `checker.ErrInvalidStatusCode` for `4xx` and `5xx` responses.
 - `DBChecker` and `TCPChecker` use `checker.ErrTimeout` as the timeout cause for
@@ -236,7 +242,10 @@ By default it checks:
 - `https://cp.cloudflare.com/generate_204`
 - `https://connectivity-check.ubuntu.com`
 
-Use `checker.WithURLs` to replace that default list:
+Use `checker.WithURLs` with at least one URL to replace that default list. An
+empty replacement keeps the built-in defaults. The checker sends requests to all
+configured URLs concurrently and reports healthy as soon as any one returns
+`200 OK` or `204 No Content`; remaining requests are canceled.
 
 ```go
 check := checker.NewOnlineChecker(
@@ -258,7 +267,7 @@ if err := check.Check(context.Background()); err != nil {
 `*database/sql.DB` satisfies that interface, so you can use it directly:
 
 ```go
-var db *sql.DB
+var db *sql.DB // initialized by your application
 
 check := checker.NewDBChecker(db, 5*time.Second)
 
@@ -282,6 +291,9 @@ if err := ready.Check(context.Background()); err != nil {
 ready.Ready()
 ```
 
+Pass a non-nil sentinel error when the gate should start unhealthy. Passing
+`nil` makes the checker report healthy before `Ready` is called.
+
 ## ⏱️ Manual probe usage
 
 If you do not need the `server` package, you can work directly with a probe:
@@ -298,8 +310,11 @@ tick := <-ticks
 log.Printf("%s healthy=%t", tick.Name(), tick.Error() == nil)
 ```
 
-`Stop` cancels any check still running and waits for the probe goroutine to
-exit, or returns the supplied context error if that wait is canceled.
+If the probe should keep running, continue receiving from `ticks` until you call
+`Stop`; the direct probe channel is buffered but does not drop unread ticks.
+`Stop` cancels the context for any check still running and waits for the probe
+goroutine to exit, or returns the supplied context error if that wait is
+canceled.
 
 ## 👀 Working with observers
 
@@ -321,6 +336,9 @@ for name, observer := range s.Observers("readyz") {
 	log.Printf("%s ready=%t", name, observer.Error() == nil)
 }
 ```
+
+The iteration order is unspecified. Collect and sort the service names if you
+need stable endpoint output, logs, or tests.
 
 ## 🛠️ Development
 

--- a/checker/db.go
+++ b/checker/db.go
@@ -12,6 +12,7 @@ var _ Checker = (*DBChecker)(nil)
 
 // NewDBChecker returns a DBChecker that pings pinger.
 //
+// The pinger must be a non-nil, initialized implementation of sql.Pinger.
 // The timeout is applied via [context.WithTimeoutCause] during Check. Passing 0
 // uses the package default of 30 seconds.
 func NewDBChecker(pinger sql.Pinger, t time.Duration) *DBChecker {

--- a/checker/online.go
+++ b/checker/online.go
@@ -42,7 +42,8 @@ type OnlineChecker struct {
 //
 // Requests are issued concurrently with the supplied context. Individual request
 // errors are ignored unless every configured URL fails or returns an unexpected
-// status code.
+// status code. The checker cancels remaining requests after the first healthy
+// response.
 func (c *OnlineChecker) Check(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err

--- a/probe/doc.go
+++ b/probe/doc.go
@@ -12,7 +12,9 @@
 //   - Error() returns the latest checker error, or nil when healthy.
 //
 // Ticks are delivered asynchronously on a channel so higher-level code can fan
-// them out to observers or aggregate them into service-level health.
+// them out to observers or aggregate them into service-level health. Direct
+// users should keep receiving from the channel while the probe is running; the
+// channel is buffered but does not drop unread ticks.
 //
 // # Scheduling behavior
 //
@@ -30,8 +32,8 @@
 //
 // Start is idempotent while a probe is running: repeated calls with a live
 // context return the same channel once startup has completed. Stop is also
-// idempotent and cancels any in-flight check before waiting for the probe
-// goroutine to exit or the supplied context to expire.
+// idempotent and cancels the context for any in-flight check before waiting for
+// the probe goroutine to exit or the supplied context to expire.
 //
 // # Example
 //

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -46,8 +46,11 @@ type activeProbe struct {
 // context error and no tick channel. If Stop cancels startup before the initial
 // result can be emitted, Start can return nil error with a closed tick channel
 // and no initial tick. Canceling ctx after Start returns does not stop the
-// probe; use Stop to end the probe lifecycle. If the probe is already running
-// and ctx remains valid through readiness, Start returns the existing channel.
+// probe; use Stop to end the probe lifecycle. Keep receiving from the returned
+// channel while the probe is running. If the period is zero or negative, Start
+// returns a closed channel containing one tick whose error wraps
+// ErrInvalidPeriod. If the probe is already running and ctx remains valid
+// through readiness, Start returns the existing channel.
 func (p *Probe) Start(ctx context.Context) (<-chan *Tick, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
@@ -106,8 +109,9 @@ func (p *Probe) ensureStarted(ctx context.Context) (<-chan *Tick, <-chan struct{
 // Stop stops the probe.
 //
 // Stop is safe to call before Start and safe to call multiple times. It cancels
-// any in-flight check, closes the tick channel once the worker exits, and waits
-// for the probe goroutine to finish.
+// the context for any in-flight check, closes the tick channel once the worker
+// exits, and waits for the probe goroutine to finish. If ctx expires while
+// waiting, Stop returns ctx.Err().
 func (p *Probe) Stop(ctx context.Context) error {
 	p.mux.Lock()
 

--- a/server/doc.go
+++ b/server/doc.go
@@ -14,9 +14,11 @@
 //
 // Register services and observers during setup, then call Start to run the
 // orchestration. Start waits for initial checks to finish or the supplied context
-// to be canceled before returning. Call Stop after Start has returned, typically
-// from process shutdown. Existing observers continue to work across service
-// restarts.
+// to be canceled before returning. Observer state is updated asynchronously from
+// probe ticks, so Start completion does not mean observers have processed the
+// initial result. Call Stop after Start has returned, typically from process
+// shutdown. Existing observers continue to work across service restarts and
+// retain their previous state until new ticks arrive.
 //
 // # Example
 //

--- a/server/server.go
+++ b/server/server.go
@@ -40,7 +40,8 @@ func (s *Server) Register(name string, regs ...*Registration) {
 
 // Observers returns all observers of the given kind.
 //
-// Services that do not have that observer kind are skipped.
+// Services that do not have that observer kind are skipped. Iteration order is
+// unspecified.
 func (s *Server) Observers(kind string) iter.Seq2[string, *subscriber.Observer] {
 	return func(yield func(string, *subscriber.Observer) bool) {
 		for name, service := range s.services {
@@ -118,7 +119,9 @@ func (s *Server) Start(ctx context.Context) error {
 
 // Stop stops all registered services.
 //
-// Stop is idempotent.
+// Stop is idempotent. If ctx expires before shutdown work finishes, Stop returns
+// an error and keeps the server marked running so callers can retry with a valid
+// context.
 func (s *Server) Stop(ctx context.Context) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()

--- a/server/service.go
+++ b/server/service.go
@@ -93,11 +93,12 @@ func (s *Service) Observe(kind string, names ...string) error {
 // Start starts all registered probes and begins fan-out to subscribers.
 //
 // Existing observers continue receiving updates if the service is stopped and
-// started again later. Start waits for each probe's initial check before
-// returning. Repeated calls while the service is running are no-ops. Call Stop
-// after Start has returned during normal shutdown. If a probe fails to start,
-// Start cleans up partially started probes and subscriptions, leaves the service
-// stopped, and the service may be started again later.
+// started again later. Start runs probes concurrently and waits for each probe's
+// initial check before returning; observer state is updated asynchronously after
+// those ticks are fanned out. Repeated calls while the service is running are
+// no-ops. Call Stop after Start has returned during normal shutdown. If a probe
+// fails to start, Start cleans up partially started probes and subscriptions,
+// leaves the service stopped, and the service may be started again later.
 func (s *Service) Start(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -132,7 +133,9 @@ func (s *Service) Start(ctx context.Context) error {
 // Stop is safe before Start and safe to call multiple times. It waits for
 // in-flight fan-in and fan-out work to finish before returning. Observer
 // instances are preserved; if the service is started again later, those
-// observers are attached to fresh subscribers.
+// observers are attached to fresh subscribers. If ctx expires before shutdown
+// work finishes, Stop returns an error and keeps the service marked running so
+// callers can retry with a valid context.
 func (s *Service) Stop(ctx context.Context) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()

--- a/sql/doc.go
+++ b/sql/doc.go
@@ -5,9 +5,9 @@
 //
 // # Example
 //
-//	import databasesql "database/sql"
+//	import "database/sql"
 //
-//	var db *databasesql.DB
+//	var db *sql.DB // initialized by your application
 //	check := checker.NewDBChecker(db, 5*time.Second)
 //
 //	if err := check.Check(context.Background()); err != nil {

--- a/subscriber/observer.go
+++ b/subscriber/observer.go
@@ -69,6 +69,9 @@ func (o *Observer) Restart(sub *Subscriber) {
 }
 
 // Wait blocks until the current observe loop exits.
+//
+// Direct callers should close the current subscriber before waiting; otherwise
+// Wait can block indefinitely.
 func (o *Observer) Wait() {
 	o.wg.Wait()
 }


### PR DESCRIPTION
## What

- Clarify lifecycle and shutdown contracts for probes, services, servers, and observers.
- Document online-checker URL replacement, concurrent request behavior, and first-success cancellation.
- Clarify DB checker pinger initialization and readiness-gate nil-error behavior in first-use docs and GoDoc.

## Why

- These contracts affect service authors wiring health endpoints and direct package consumers building custom probe or observer flows.
- The updates reduce the risk of assuming observer state is synchronized with Start, expecting Stop to forcibly interrupt non-cooperative checks, depending on observer iteration order, or accidentally starting a readiness gate healthy.

## Testing

- `go test ./checker ./probe ./subscriber ./server ./net ./sql -run 'Example|TestOnlineChecker|TestStopReturnsContextError|TestServiceStartRunsInitialChecksConcurrently|Test.*Observers' -count=1` - passed
- `make lint` - passed
