### PR TITLE
feat(watcher): add health state subscriptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ Top-level packages:
 - `probe/`: periodic execution of a `checker.Checker`, producing `probe.Tick` values.
 - `subscriber/`: best-effort tick fan-out plus observer state tracking.
 - `server/`: orchestration for registering probes per service, creating observers, and managing start/stop lifecycle.
+- `watcher/`: shared subscription interface returned by observer and server watch entry points.
 - `net/`: small network-related interfaces used by checkers.
 - `sql/`: small SQL-related interfaces used by checkers.
 - `internal/test/`: test helpers such as building URLs for the local status service.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ import "github.com/alexfalkowski/go-health/v2/server"
 | `probe` | Periodically runs a checker and emits ticks. |
 | `subscriber` | Best-effort tick fan-out and latest-error tracking for selected probe names. |
 | `server` | Registers probes per service, creates observers, and manages lifecycle. |
+| `watcher` | Shared subscription interface returned by observer and server watch entry points. |
 | `net` | Small interfaces used to customize network dialing. |
 | `sql` | Small interfaces used to customize database pinging. |
 
@@ -87,6 +88,10 @@ import "github.com/alexfalkowski/go-health/v2/server"
   slow observer can miss intermediate ticks.
 - `subscriber.Observer` starts with `nil` errors for every tracked probe name
   and updates as ticks arrive.
+- `server.Error(kind)` joins the current errors for every service that has an
+  observer of that kind.
+- `server.Watch(kind)` streams the current error for that observer kind and
+  future tick-derived errors until the returned watcher is stopped.
 - `server.Service` and `server.Server` keep observer instances across
   stop/start cycles, so existing observers continue receiving ticks after a
   restart.
@@ -169,29 +174,17 @@ func main() {
 	}
 	defer s.Stop(context.Background())
 
-	livez, err := s.Observer("payments", "livez")
-	if err != nil {
-		log.Fatal(err)
+	if err := s.Error("livez"); err != nil {
+		log.Printf("livez unhealthy: %v", err)
+	}
+
+	if err := s.Error("readyz"); err != nil {
+		log.Printf("readyz unhealthy: %v", err)
 	}
 
 	readyz, err := s.Observer("payments", "readyz")
 	if err != nil {
 		log.Fatal(err)
-	}
-
-	readyChecker.Ready()
-
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if readyz.Error() == nil {
-			break
-		}
-
-		time.Sleep(10 * time.Millisecond)
-	}
-
-	if err := livez.Error(); err != nil {
-		log.Printf("livez unhealthy: %v", err)
 	}
 
 	for name, err := range readyz.Errors() {
@@ -339,6 +332,33 @@ for name, observer := range s.Observers("readyz") {
 
 The iteration order is unspecified. Collect and sort the service names if you
 need stable endpoint output, logs, or tests.
+
+When a transport needs a single answer for all services with the same observer
+kind, use `Server.Error(kind)`:
+
+```go
+if err := s.Error("readyz"); err != nil {
+	log.Printf("readyz unhealthy: %v", err)
+}
+```
+
+To avoid polling, watch the observer kind and report each update. The stream
+sends the current state first, then future tick-derived states:
+
+```go
+func streamReady(s *server.Server, send func(bool) error) error {
+	watcher := s.Watch("readyz")
+	defer watcher.Close()
+
+	for err := range watcher.Receive() {
+		if err := send(err == nil); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+```
 
 ## 🛠️ Development
 

--- a/server/doc.go
+++ b/server/doc.go
@@ -20,6 +20,11 @@
 // shutdown. Existing observers continue to work across service restarts and
 // retain their previous state until new ticks arrive.
 //
+// Server.Error summarizes the current health for every service that registered
+// a given observer kind. Server.Watch returns a watcher for the current error
+// for that kind and future tick-derived errors so transport implementations can
+// report state updates without adding their own ticker.
+//
 // # Example
 //
 //	s := server.NewServer()
@@ -38,12 +43,7 @@
 //	}
 //	defer s.Stop(context.Background())
 //
-//	ob, err := s.Observer("payments", "livez")
-//	if err != nil {
-//		log.Fatal(err)
-//	}
-//
-//	if err := ob.Error(); err != nil {
+//	if err := s.Error("livez"); err != nil {
 //		log.Printf("payments unhealthy: %v", err)
 //	}
 package server

--- a/server/example_test.go
+++ b/server/example_test.go
@@ -23,12 +23,6 @@ func ExampleNewServer() {
 		return
 	}
 
-	observer, err := s.Observer("payments", "readyz")
-	if err != nil {
-		fmt.Println(err)
-		return
-	}
-
 	if err := s.Start(context.Background()); err != nil {
 		fmt.Println(err)
 		return
@@ -37,29 +31,33 @@ func ExampleNewServer() {
 		_ = s.Stop(context.Background())
 	}()
 
-	fmt.Println(waitForCondition(func() bool {
-		return errors.Is(observer.Error(), errNotReady)
+	watcher := s.Watch("readyz")
+	defer watcher.Close()
+
+	fmt.Println(waitForUpdate(watcher.Receive(), func(err error) bool {
+		return errors.Is(err, errNotReady)
 	}))
 
 	ready.Ready()
 
-	fmt.Println(waitForCondition(func() bool {
-		return observer.Error() == nil
+	fmt.Println(waitForUpdate(watcher.Receive(), func(err error) bool {
+		return err == nil
 	}))
 	// Output:
 	// true
 	// true
 }
 
-func waitForCondition(fn func() bool) bool {
-	deadline := time.Now().Add(250 * time.Millisecond)
-	for time.Now().Before(deadline) {
-		if fn() {
-			return true
+func waitForUpdate(updates <-chan error, match func(error) bool) bool {
+	timeout := time.After(250 * time.Millisecond)
+	for {
+		select {
+		case err := <-updates:
+			if match(err) {
+				return true
+			}
+		case <-timeout:
+			return false
 		}
-
-		time.Sleep(5 * time.Millisecond)
 	}
-
-	return fn()
 }

--- a/server/restart_test.go
+++ b/server/restart_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-//nolint:err113
 func TestRestartKeepsObserverReceivingTicks(t *testing.T) {
 	s := server.NewServer()
 	t.Cleanup(func() { _ = s.Stop(context.Background()) })

--- a/server/server.go
+++ b/server/server.go
@@ -3,9 +3,11 @@ package server
 import (
 	"context"
 	"errors"
+	"fmt"
 	"iter"
 
 	"github.com/alexfalkowski/go-health/v2/subscriber"
+	"github.com/alexfalkowski/go-health/v2/watcher"
 	"github.com/alexfalkowski/go-sync"
 )
 
@@ -55,6 +57,50 @@ func (s *Server) Observers(kind string) iter.Seq2[string, *subscriber.Observer] 
 			}
 		}
 	}
+}
+
+// Error returns all non-nil observer errors for kind joined into one error.
+//
+// Services without kind are skipped. Each service error is annotated with the
+// service name before being joined. A nil result means every registered observer
+// for kind is currently healthy, or no service has registered kind.
+func (s *Server) Error(kind string) error {
+	errs := make([]error, 0)
+	for name, observer := range s.Observers(kind) {
+		if err := observer.Error(); err != nil {
+			errs = append(errs, fmt.Errorf("%s: %w", name, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// Watch returns a watcher for current and future aggregate observer errors for kind.
+//
+// Services without kind are skipped. The watcher receives the current aggregate
+// error immediately, then receives the current aggregate error again after any
+// observer of kind receives a probe tick. Sends are best-effort and coalesced to
+// the latest error when the receiver is slow. Close the watcher when the receiver
+// no longer needs updates. Register and Observe remain setup-time calls and are not
+// added to an existing watch.
+func (s *Server) Watch(kind string) watcher.Subscription {
+	sub := &subscription{
+		updates: make(chan error, 1),
+		server:  s,
+		kind:    kind,
+	}
+	sub.start()
+
+	return sub
+}
+
+func (s *Server) observers(kind string) []*subscriber.Observer {
+	observers := make([]*subscriber.Observer, 0)
+	for _, observer := range s.Observers(kind) {
+		observers = append(observers, observer)
+	}
+
+	return observers
 }
 
 // Observer returns an observer for the service name and observer kind.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -296,7 +296,6 @@ func TestValidDBChecker(t *testing.T) {
 	})
 }
 
-//nolint:err113
 func TestInvalidDBChecker(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		s := server.NewServer()
@@ -319,7 +318,6 @@ func TestInvalidDBChecker(t *testing.T) {
 	})
 }
 
-//nolint:err113
 func TestValidReadyChecker(t *testing.T) {
 	synctest.Test(t, func(t *testing.T) {
 		s := server.NewServer()
@@ -484,6 +482,94 @@ func TestGRPCObservers(t *testing.T) {
 	require.Empty(t, names)
 }
 
+func TestServerErrorJoinsObserverErrorsForKind(t *testing.T) {
+	s := server.NewServer()
+	t.Cleanup(func() { _ = s.Stop(context.Background()) })
+
+	errPayments := errors.New("payments unavailable")
+	errSearch := errors.New("search unavailable")
+	errIgnored := errors.New("ignored unavailable")
+	paymentsReady := checker.NewReadyChecker(errPayments)
+	searchReady := checker.NewReadyChecker(errSearch)
+	ignoredReady := checker.NewReadyChecker(errIgnored)
+
+	paymentsRegistration := server.NewRegistration("ready", time.Hour, paymentsReady)
+	searchRegistration := server.NewRegistration("ready", time.Hour, searchReady)
+	ignoredRegistration := server.NewRegistration("ready", time.Hour, ignoredReady)
+
+	s.Register("payments", paymentsRegistration)
+	s.Register("search", searchRegistration)
+	s.Register("ignored", ignoredRegistration)
+
+	require.NoError(t, s.Observe("payments", "grpc", paymentsRegistration.Name))
+	require.NoError(t, s.Observe("search", "grpc", searchRegistration.Name))
+	require.NoError(t, s.Observe("ignored", "livez", ignoredRegistration.Name))
+
+	require.NoError(t, s.Start(t.Context()))
+
+	require.Eventually(t, func() bool {
+		err := s.Error("grpc")
+
+		return errors.Is(err, errPayments) && errors.Is(err, errSearch)
+	}, time.Second, 10*time.Millisecond)
+
+	err := s.Error("grpc")
+	require.ErrorContains(t, err, "payments:")
+	require.ErrorContains(t, err, "search:")
+	require.NotErrorIs(t, err, errIgnored)
+}
+
+func TestServerWatchWaitsForKindStatusChange(t *testing.T) {
+	s := server.NewServer()
+	t.Cleanup(func() { _ = s.Stop(context.Background()) })
+
+	checker := &dynamicChecker{}
+	registration := server.NewRegistration("dynamic", 10*time.Millisecond, checker)
+	s.Register("test", registration)
+
+	require.NoError(t, s.Observe("test", "grpc", registration.Name))
+	require.NoError(t, s.Start(t.Context()))
+
+	watcher := s.Watch("grpc")
+	defer watcher.Close()
+	updates := watcher.Receive()
+	require.NoError(t, receiveError(t, updates))
+
+	errChanged := errors.New("changed")
+	checker.Set(errChanged)
+
+	require.ErrorIs(t, receiveMatchingError(t, updates, func(err error) bool {
+		return errors.Is(err, errChanged)
+	}), errChanged)
+
+	watcher.Close()
+	receiveClosed(t, updates)
+}
+
+func TestServerWatcherCoalescesPendingUpdates(t *testing.T) {
+	s := server.NewServer()
+	t.Cleanup(func() { _ = s.Stop(context.Background()) })
+
+	errNotReady := errors.New("not ready")
+	checker := checker.NewReadyChecker(errNotReady)
+	registration := server.NewRegistration("ready", time.Hour, checker)
+	s.Register("test", registration)
+
+	require.NoError(t, s.Observe("test", "grpc", registration.Name))
+	require.NoError(t, s.Start(t.Context()))
+
+	require.Eventually(t, func() bool {
+		return errors.Is(s.Error("grpc"), errNotReady)
+	}, time.Second, 10*time.Millisecond)
+
+	watcher := s.Watch("grpc")
+	updates := watcher.Receive()
+
+	watcher.Close()
+	require.ErrorIs(t, receiveError(t, updates), errNotReady)
+	receiveClosed(t, updates)
+}
+
 func TestInvalidObservers(t *testing.T) {
 	s := server.NewServer()
 	defer func() { _ = s.Stop(context.Background()) }()
@@ -500,6 +586,54 @@ func TestInvalidObservers(t *testing.T) {
 	_ = s.Observe("test", "livez", r.Name)
 	_, err := s.Observer("bob", "livez")
 	require.Error(t, err)
+}
+
+func receiveError(t *testing.T, updates <-chan error) error {
+	t.Helper()
+
+	select {
+	case err, ok := <-updates:
+		require.True(t, ok)
+		return err
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for observer update")
+		return nil
+	}
+}
+
+func receiveMatchingError(t *testing.T, updates <-chan error, match func(error) bool) error {
+	t.Helper()
+
+	timeout := time.After(time.Second)
+	for {
+		select {
+		case err, ok := <-updates:
+			require.True(t, ok)
+			if match(err) {
+				return err
+			}
+		case <-timeout:
+			require.Fail(t, "timed out waiting for matching observer update")
+			return nil
+		}
+	}
+}
+
+func receiveClosed(t *testing.T, updates <-chan error) {
+	t.Helper()
+
+	timeout := time.After(time.Second)
+	for {
+		select {
+		case _, ok := <-updates:
+			if !ok {
+				return
+			}
+		case <-timeout:
+			require.Fail(t, "timed out waiting for observer updates to close")
+			return
+		}
+	}
 }
 
 func BenchmarkValidHTTPChecker(b *testing.B) {

--- a/server/service.go
+++ b/server/service.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/alexfalkowski/go-health/v2/probe"
 	"github.com/alexfalkowski/go-health/v2/subscriber"
+	"github.com/alexfalkowski/go-health/v2/watcher"
 	"github.com/alexfalkowski/go-sync"
 )
 
@@ -69,6 +70,34 @@ func (s *Service) Observer(kind string) (*subscriber.Observer, error) {
 	}
 
 	return observer, nil
+}
+
+// Error returns the observer error for kind.
+//
+// It returns ErrObserverNotFound if kind has not been registered. A nil result
+// means the observer is currently healthy.
+func (s *Service) Error(kind string) error {
+	observer, err := s.Observer(kind)
+	if err != nil {
+		return err
+	}
+
+	return observer.Error()
+}
+
+// Watch returns a watcher for current and future observer errors for kind.
+//
+// It returns ErrObserverNotFound if kind has not been registered. The watcher
+// receives the observer's current error immediately, then receives the current
+// error again after each matching probe tick is processed. Close the watcher
+// when the receiver no longer needs updates.
+func (s *Service) Watch(kind string) (watcher.Subscription, error) {
+	observer, err := s.Observer(kind)
+	if err != nil {
+		return nil, err
+	}
+
+	return observer.Watch(), nil
 }
 
 // Observe registers an observer kind that tracks the probes listed in names.

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -69,7 +69,39 @@ func TestServiceObserveKeepsOriginalProbeSetForExistingKind(t *testing.T) {
 	require.Equal(t, []string{first.Name}, sameObserver.Names())
 }
 
-//nolint:err113
+func TestServiceErrorReturnsObserverError(t *testing.T) {
+	s := server.NewService()
+	t.Cleanup(func() { _ = s.Stop(context.Background()) })
+
+	errNotReady := errors.New("not ready")
+	registration := server.NewRegistration("ready", time.Hour, checker.NewReadyChecker(errNotReady))
+	s.Register(registration)
+	require.NoError(t, s.Observe("readyz", registration.Name))
+	watcher, err := s.Watch("readyz")
+	require.NoError(t, err)
+	defer watcher.Close()
+	updates := watcher.Receive()
+	require.NoError(t, receiveError(t, updates))
+
+	require.NoError(t, s.Start(t.Context()))
+
+	require.Eventually(t, func() bool {
+		return errors.Is(s.Error("readyz"), errNotReady)
+	}, time.Second, 10*time.Millisecond)
+	require.ErrorIs(t, receiveMatchingError(t, updates, func(err error) bool {
+		return errors.Is(err, errNotReady)
+	}), errNotReady)
+}
+
+func TestServiceErrorAndWatchRejectUnknownObserver(t *testing.T) {
+	s := server.NewService()
+
+	require.ErrorIs(t, s.Error("readyz"), server.ErrObserverNotFound)
+
+	_, err := s.Watch("readyz")
+	require.ErrorIs(t, err, server.ErrObserverNotFound)
+}
+
 func TestServiceStopBeforeStartClosesObservers(t *testing.T) {
 	s := server.NewService()
 	errNotReady := errors.New("not ready")

--- a/server/subscription.go
+++ b/server/subscription.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"github.com/alexfalkowski/go-health/v2/subscriber"
+	"github.com/alexfalkowski/go-health/v2/watcher"
+	"github.com/alexfalkowski/go-sync"
+)
+
+type subscription struct {
+	updates  chan error
+	server   *Server
+	kind     string
+	watchers []watcher.Subscription
+	wg       sync.WaitGroup
+	once     sync.Once
+}
+
+func (s *subscription) Receive() <-chan error {
+	return s.updates
+}
+
+func (s *subscription) Close() {
+	s.once.Do(func() {
+		for _, sub := range s.watchers {
+			sub.Close()
+		}
+
+		s.wg.Wait()
+		close(s.updates)
+	})
+}
+
+// start publishes the current aggregate state and begins relaying observer updates.
+//
+// Each observer update means some underlying probe tick was processed. The
+// watcher responds by recomputing the server-level error and publishing that
+// snapshot to its channel.
+func (s *subscription) start() {
+	s.publish(s.snapshot())
+
+	for _, observer := range s.server.observers(s.kind) {
+		s.watch(observer)
+	}
+}
+
+// watch relays one observer's updates into the aggregate channel.
+func (s *subscription) watch(observer *subscriber.Observer) {
+	sub := observer.Watch()
+	s.watchers = append(s.watchers, sub)
+
+	s.wg.Go(func() {
+		for range sub.Receive() {
+			s.publish(s.snapshot())
+		}
+	})
+}
+
+func (s *subscription) snapshot() error {
+	return s.server.Error(s.kind)
+}
+
+func (s *subscription) publish(err error) {
+	if s.send(err) {
+		return
+	}
+
+	s.drop()
+	_ = s.send(err)
+}
+
+func (s *subscription) send(err error) bool {
+	select {
+	case s.updates <- err:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *subscription) drop() {
+	select {
+	case <-s.updates:
+	default:
+	}
+}

--- a/subscriber/doc.go
+++ b/subscriber/doc.go
@@ -19,6 +19,11 @@
 // Joined errors are annotated with the probe name so they are still useful when
 // logged or returned directly.
 //
+// Watch returns a watcher for an observer's current error and future
+// tick-derived errors. It is useful for transport implementations that need to
+// stream state updates without adding their own ticker. The watcher keeps only the
+// latest pending state so slow receivers do not block probe delivery.
+//
 // # Delivery semantics
 //
 // Subscriber.Send is best-effort and non-blocking. If the buffer is full, the

--- a/subscriber/observer.go
+++ b/subscriber/observer.go
@@ -3,6 +3,7 @@ package subscriber
 import (
 	"slices"
 
+	"github.com/alexfalkowski/go-health/v2/watcher"
 	"github.com/alexfalkowski/go-sync"
 )
 
@@ -20,7 +21,12 @@ func NewObserver(names []string, sub *Subscriber) *Observer {
 		errs[n] = nil
 	}
 
-	ob := &Observer{errors: errs, names: names, mux: sync.RWMutex{}}
+	ob := &Observer{
+		errors:   errs,
+		names:    names,
+		watchers: make(map[*subscription]struct{}),
+		mux:      sync.RWMutex{},
+	}
 	ob.start(sub)
 
 	return ob
@@ -28,10 +34,11 @@ func NewObserver(names []string, sub *Subscriber) *Observer {
 
 // Observer maintains the latest health state for probe ticks it receives.
 type Observer struct {
-	errors Errors
-	names  []string
-	mux    sync.RWMutex
-	wg     sync.WaitGroup
+	errors   Errors
+	watchers map[*subscription]struct{}
+	names    []string
+	wg       sync.WaitGroup
+	mux      sync.RWMutex
 }
 
 // Error returns all non-nil errors combined into a single error.
@@ -55,6 +62,28 @@ func (o *Observer) Errors() Errors {
 // Names returns the probe names tracked by the observer.
 func (o *Observer) Names() []string {
 	return slices.Clone(o.names)
+}
+
+// Watch returns a watcher for current and future observer errors.
+//
+// The watcher receives the observer's current error immediately, then receives
+// the current error again after each matching probe tick is processed. Sends are
+// best-effort and coalesced to the latest error when the receiver is slow. Close
+// the watcher when the receiver no longer needs updates.
+func (o *Observer) Watch() watcher.Subscription {
+	sub := &subscription{
+		updates: make(chan error, 1),
+		done:    make(chan struct{}),
+	}
+
+	o.mux.Lock()
+	o.watchers[sub] = struct{}{}
+	sub.publish(o.errors.Error())
+	o.mux.Unlock()
+
+	go o.remove(sub)
+
+	return sub
 }
 
 // Restart waits for the current subscriber to finish and starts observing sub.
@@ -86,6 +115,24 @@ func (o *Observer) observe(sub *Subscriber) {
 	for t := range sub.Receive() {
 		o.mux.Lock()
 		o.errors.Set(t.Name(), t.Error())
+		err := o.errors.Error()
+		o.send(err)
 		o.mux.Unlock()
 	}
+}
+
+func (o *Observer) send(err error) {
+	for sub := range o.watchers {
+		if !sub.publish(err) {
+			delete(o.watchers, sub)
+		}
+	}
+}
+
+func (o *Observer) remove(sub *subscription) {
+	<-sub.closed()
+
+	o.mux.Lock()
+	delete(o.watchers, sub)
+	o.mux.Unlock()
 }

--- a/subscriber/subscriber_test.go
+++ b/subscriber/subscriber_test.go
@@ -127,6 +127,61 @@ func TestObserverErrorsReturnsCopy(t *testing.T) {
 	require.ErrorIs(t, ob.Error(), errDB)
 }
 
+func TestObserverWatchSendsCurrentErrorAndUpdates(t *testing.T) {
+	s := subscriber.NewSubscriber([]string{dbProbeName})
+	ob := subscriber.NewObserver([]string{dbProbeName}, s)
+	t.Cleanup(func() {
+		s.Close()
+		ob.Wait()
+	})
+
+	watcher := ob.Watch()
+	defer watcher.Close()
+	updates := watcher.Receive()
+
+	require.NoError(t, receiveError(t, updates))
+
+	errDB := errors.New("db failed")
+	s.Send(probe.NewTick(dbProbeName, errDB))
+
+	require.ErrorIs(t, receiveError(t, updates), errDB)
+}
+
+func TestObserverWatchClosesWhenStopped(t *testing.T) {
+	s := subscriber.NewSubscriber([]string{dbProbeName})
+	ob := subscriber.NewObserver([]string{dbProbeName}, s)
+	t.Cleanup(func() {
+		s.Close()
+		ob.Wait()
+	})
+
+	watcher := ob.Watch()
+	updates := watcher.Receive()
+	require.NoError(t, receiveError(t, updates))
+
+	watcher.Close()
+	_, ok := receive(t, updates)
+	require.False(t, ok)
+}
+
+func TestObserverWatchSendsTicksWithoutStatusChange(t *testing.T) {
+	s := subscriber.NewSubscriber([]string{dbProbeName})
+	ob := subscriber.NewObserver([]string{dbProbeName}, s)
+	t.Cleanup(func() {
+		s.Close()
+		ob.Wait()
+	})
+
+	watcher := ob.Watch()
+	defer watcher.Close()
+	updates := watcher.Receive()
+	require.NoError(t, receiveError(t, updates))
+
+	s.Send(probe.NewTick(dbProbeName, nil))
+
+	require.NoError(t, receiveError(t, updates))
+}
+
 func TestErrorsErrorJoinsAnnotatedErrors(t *testing.T) {
 	errDB := errors.New("db failed")
 	errCache := errors.New("cache failed")
@@ -140,4 +195,25 @@ func TestErrorsErrorJoinsAnnotatedErrors(t *testing.T) {
 	require.ErrorIs(t, err, errCache)
 	require.ErrorContains(t, err, "db:")
 	require.ErrorContains(t, err, "cache:")
+}
+
+func receiveError(t *testing.T, updates <-chan error) error {
+	t.Helper()
+
+	err, ok := receive(t, updates)
+	require.True(t, ok)
+
+	return err
+}
+
+func receive(t *testing.T, updates <-chan error) (error, bool) {
+	t.Helper()
+
+	select {
+	case err, ok := <-updates:
+		return err, ok
+	case <-time.After(time.Second):
+		require.Fail(t, "timed out waiting for observer update")
+		return nil, false
+	}
 }

--- a/subscriber/subscription.go
+++ b/subscriber/subscription.go
@@ -1,0 +1,64 @@
+package subscriber
+
+import "github.com/alexfalkowski/go-sync"
+
+type subscription struct {
+	updates chan error
+	done    chan struct{}
+	mux     sync.Mutex
+	once    sync.Once
+}
+
+func (s *subscription) Receive() <-chan error {
+	return s.updates
+}
+
+func (s *subscription) Close() {
+	s.once.Do(func() {
+		s.mux.Lock()
+		defer s.mux.Unlock()
+
+		close(s.done)
+		close(s.updates)
+	})
+}
+
+func (s *subscription) publish(err error) bool {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	select {
+	case <-s.done:
+		return false
+	default:
+	}
+
+	if s.send(err) {
+		return true
+	}
+
+	s.drop()
+	_ = s.send(err)
+
+	return true
+}
+
+func (s *subscription) closed() <-chan struct{} {
+	return s.done
+}
+
+func (s *subscription) send(err error) bool {
+	select {
+	case s.updates <- err:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *subscription) drop() {
+	select {
+	case <-s.updates:
+	default:
+	}
+}

--- a/watcher/subscription.go
+++ b/watcher/subscription.go
@@ -1,0 +1,11 @@
+// Package watcher defines health state watch subscriptions.
+package watcher
+
+// Subscription receives current and future health error snapshots.
+//
+// Receive returns a channel with the current error snapshot followed by future
+// snapshots. Close releases the subscription and closes the receive channel.
+type Subscription interface {
+	Receive() <-chan error
+	Close()
+}


### PR DESCRIPTION
## What

- Add a shared watcher.Subscription interface for health state watch handles.
- Return watcher.Subscription from observer, service, and server watch entry points.
- Keep subscriber and server subscription implementations private while preserving coalesced latest-state delivery.
- Update README, package docs, examples, and tests for Receive and Close semantics.

## Why

- Transport adapters such as gRPC health need a simple way to check current health and stream changes without owning their own ticker.
- A shared subscription interface avoids exposing subscriber/server implementation details while keeping the watch API consistent across packages.

## Testing

- go test ./watcher ./subscriber ./server -count=1 - passed
- go test ./... -count=1 - passed
- make lint - passed
- make specs - passed

AI-assisted-by: [Codex](https://openai.com/codex/)