### PR TITLE
docs(readme): clarify health observer contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/alexfalkowski/go-health/v2.svg)](https://pkg.go.dev/github.com/alexfalkowski/go-health/v2)
 [![Stability: Active](https://masterminds.github.io/stability/active.svg)](https://masterminds.github.io/stability/active.html)
 
-# 🩺 Health Monitoring Pattern
+# 🩺 go-health
 
-`go-health` is a small Go library for building asynchronous health monitoring.
-It separates the problem into four layers:
+`go-health` is a small Go library for building asynchronous health monitoring
+in Go services. It separates the problem into four layers:
 
 1. `checker`: how to test one dependency.
 2. `probe`: when to run that test.
@@ -89,9 +89,12 @@ import "github.com/alexfalkowski/go-health/v2/server"
 - `subscriber.Observer` starts with `nil` errors for every tracked probe name
   and updates as ticks arrive.
 - `server.Error(kind)` joins the current errors for every service that has an
-  observer of that kind.
+  observer of that kind. A `nil` result means every matching observer is
+  healthy, or no service has registered that observer kind.
 - `server.Watch(kind)` streams the current error for that observer kind and
-  future tick-derived errors until the returned watcher is stopped.
+  future tick-derived errors until the returned watcher is stopped. Validate
+  setup with `Observe` or `Observer` before exposing an aggregate endpoint so a
+  misspelled kind does not look healthy.
 - `server.Service` and `server.Server` keep observer instances across
   stop/start cycles, so existing observers continue receiving ticks after a
   restart.
@@ -133,28 +136,22 @@ import (
 )
 
 func main() {
-	const (
-		timeout = 5 * time.Second
-		period  = 30 * time.Second
-	)
+	const period = 100 * time.Millisecond
+
+	errNotReady := errors.New("starting up")
+	readyChecker := checker.NewReadyChecker(errNotReady)
 
 	s := server.NewServer()
 
-	readyChecker := checker.NewReadyChecker(errors.New("starting up"))
-	apiChecker := checker.NewHTTPChecker("https://example.com/health", timeout)
-	cacheChecker := checker.NewTCPChecker("cache.internal:6379", timeout)
+	liveRegistration := server.NewRegistration("live", period, checker.NewNoopChecker())
+	readyRegistration := server.NewRegistration("ready", period, readyChecker)
 
-	apiRegistration := server.NewRegistration("api", period, apiChecker)
-	cacheRegistration := server.NewRegistration("cache", period, cacheChecker)
-	readyRegistration := server.NewRegistration("ready", time.Second, readyChecker)
-
-	s.Register("payments", apiRegistration, cacheRegistration, readyRegistration)
+	s.Register("payments", liveRegistration, readyRegistration)
 
 	if err := s.Observe(
 		"payments",
 		"livez",
-		apiRegistration.Name,
-		cacheRegistration.Name,
+		liveRegistration.Name,
 	); err != nil {
 		log.Fatal(err)
 	}
@@ -162,8 +159,7 @@ func main() {
 	if err := s.Observe(
 		"payments",
 		"readyz",
-		apiRegistration.Name,
-		cacheRegistration.Name,
+		liveRegistration.Name,
 		readyRegistration.Name,
 	); err != nil {
 		log.Fatal(err)
@@ -172,7 +168,26 @@ func main() {
 	if err := s.Start(context.Background()); err != nil {
 		log.Fatal(err)
 	}
-	defer s.Stop(context.Background())
+	defer func() {
+		_ = s.Stop(context.Background())
+	}()
+
+	readyzWatcher := s.Watch("readyz")
+	defer readyzWatcher.Close()
+
+	if !waitForUpdate(readyzWatcher.Receive(), func(err error) bool {
+		return errors.Is(err, errNotReady)
+	}) {
+		log.Fatal("readyz did not report startup state")
+	}
+
+	readyChecker.Ready()
+
+	if !waitForUpdate(readyzWatcher.Receive(), func(err error) bool {
+		return err == nil
+	}) {
+		log.Fatal("readyz did not become healthy")
+	}
 
 	if err := s.Error("livez"); err != nil {
 		log.Printf("livez unhealthy: %v", err)
@@ -191,19 +206,37 @@ func main() {
 		log.Printf("readyz %s = %v", name, err)
 	}
 }
+
+func waitForUpdate(updates <-chan error, match func(error) bool) bool {
+	timeout := time.After(time.Second)
+	for {
+		select {
+		case err := <-updates:
+			if match(err) {
+				return true
+			}
+		case <-timeout:
+			return false
+		}
+	}
+}
 ```
 
 > [!NOTE]
 > - `Observe` validates that the service exists and every named probe was registered.
-> - The first meaningful observer state arrives after the initial probe tick is processed.
+> - `Start` waits for initial checks, but observer state is updated after those
+>   probe ticks are fanned out; wait for a watcher update before treating the
+>   first observer read as authoritative.
 > - Calling `Observe` again with the same service and kind is a no-op; it does not replace the existing observer.
 
 ## 🧪 Direct checker examples
 
 ### 🌐 HTTP checker
 
-`HTTPChecker` performs a `GET` request. Redirects and other status codes below
-`400` are considered healthy; `4xx` and `5xx` responses are unhealthy.
+`HTTPChecker` performs a `GET` request using the standard `net/http` client
+redirect behavior, then evaluates the response returned by that client. Status
+codes below `400` are considered healthy; `4xx` and `5xx` responses are
+unhealthy.
 
 ```go
 check := checker.NewHTTPChecker("https://example.com/health", 5*time.Second)
@@ -343,20 +376,28 @@ if err := s.Error("readyz"); err != nil {
 ```
 
 To avoid polling, watch the observer kind and report each update. The stream
-sends the current state first, then future tick-derived states:
+sends the current state first, then future tick-derived states. Close the
+watcher when the receiver is done; the receive channel closes when the watcher
+is closed, not when the server stops.
 
 ```go
-func streamReady(s *server.Server, send func(bool) error) error {
+func streamReady(ctx context.Context, s *server.Server, send func(bool) error) error {
 	watcher := s.Watch("readyz")
 	defer watcher.Close()
 
-	for err := range watcher.Receive() {
-		if err := send(err == nil); err != nil {
-			return err
+	for {
+		select {
+		case err, ok := <-watcher.Receive():
+			if !ok {
+				return nil
+			}
+			if err := send(err == nil); err != nil {
+				return err
+			}
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
-
-	return nil
 }
 ```
 
@@ -392,6 +433,7 @@ Local test notes:
 
 ## 📚 Documentation
 
+- API reference is published at [pkg.go.dev/github.com/alexfalkowski/go-health/v2](https://pkg.go.dev/github.com/alexfalkowski/go-health/v2).
 - Package documentation lives in `doc.go` files and exported symbol comments.
 - Runnable pkg.go.dev examples live in `example_test.go` files.
 - README examples should always import `github.com/alexfalkowski/go-health/v2/...`.

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -7,6 +7,9 @@ import "context"
 // Implementations should return nil when healthy and a non-nil error when the
 // dependency is unhealthy. Callers provide the context so they can propagate
 // cancellation, deadlines, and request-scoped values into the check.
+//
+// Implementations shared across probes or registrations should be safe for
+// concurrent Check calls.
 type Checker interface {
 	Check(ctx context.Context) error
 }

--- a/checker/http.go
+++ b/checker/http.go
@@ -29,9 +29,10 @@ func NewHTTPChecker(url string, t time.Duration, opts ...Option) *HTTPChecker {
 
 // HTTPChecker performs an HTTP GET request to a URL.
 //
-// Responses with status codes below 400 are considered healthy. Responses with
-// status codes in the 4xx or 5xx range return ErrInvalidStatusCode wrapped with
-// context.
+// HTTPChecker uses the standard net/http client redirect behavior before
+// evaluating the response returned by that client. Responses with status codes
+// below 400 are considered healthy. Responses with status codes in the 4xx or
+// 5xx range return ErrInvalidStatusCode wrapped with context.
 type HTTPChecker struct {
 	client *http.Client
 	url    string

--- a/checker/online.go
+++ b/checker/online.go
@@ -10,7 +10,7 @@ import (
 
 var _ Checker = (*OnlineChecker)(nil)
 
-// ErrNotOnline is returned when none of the configured connectivity URLs appear healthy.
+// ErrNotOnline is wrapped when none of the configured connectivity URLs appear healthy.
 var ErrNotOnline = errors.New("not online")
 
 // NewOnlineChecker returns an OnlineChecker that checks whether any configured URL
@@ -27,8 +27,8 @@ func NewOnlineChecker(t time.Duration, opts ...Option) *OnlineChecker {
 	}
 }
 
-// OnlineChecker checks a list of URLs concurrently and returns ErrNotOnline if none
-// of them respond with 200 OK or 204 No Content.
+// OnlineChecker checks a list of URLs concurrently and wraps ErrNotOnline if
+// none of them respond with 200 OK or 204 No Content.
 //
 // The intent is to answer "can this process reach the outside world?" rather than
 // "is one specific upstream healthy?" Any single successful response is enough for

--- a/probe/probe.go
+++ b/probe/probe.go
@@ -16,7 +16,7 @@ var ErrInvalidPeriod = errors.New("health: invalid period")
 
 // NewProbe returns a Probe that runs check at the given period.
 //
-// The probe does not start until Start is called.
+// The check must be non-nil. The probe does not start until Start is called.
 func NewProbe(name string, period time.Duration, check checker.Checker) *Probe {
 	return &Probe{name: name, period: period, checker: check, mux: sync.Mutex{}}
 }

--- a/server/registration.go
+++ b/server/registration.go
@@ -22,14 +22,16 @@ func NewOnlineRegistration(timeout, period time.Duration, opts ...checker.Option
 
 // NewRegistration returns a registration for a checker.
 //
-// The period must be positive. Non-positive periods are reported through probe
-// and observer state as probe.ErrInvalidPeriod after the service starts.
+// The checker must be non-nil and initialized. The period must be positive.
+// Non-positive periods are reported through probe and observer state as
+// probe.ErrInvalidPeriod after the service starts.
 func NewRegistration(name string, period time.Duration, ch checker.Checker) *Registration {
 	return &Registration{Name: name, Period: period, Checker: ch}
 }
 
 // Registration describes a probe to run for a service.
 type Registration struct {
+	// Checker must be non-nil and initialized.
 	Checker checker.Checker
 	Name    string
 	// Period is the interval between checks and must be positive.

--- a/server/server.go
+++ b/server/server.go
@@ -21,6 +21,9 @@ func NewServer() *Server {
 
 // Server maintains registered services and can start or stop them as a group.
 //
+// Use NewServer to create a Server; the zero value is not initialized for
+// registration.
+//
 // Register and Observe are setup-time calls. Call Start once the server has
 // been configured, and Stop after Start has returned when the process is shutting
 // down.
@@ -81,8 +84,9 @@ func (s *Server) Error(kind string) error {
 // error immediately, then receives the current aggregate error again after any
 // observer of kind receives a probe tick. Sends are best-effort and coalesced to
 // the latest error when the receiver is slow. Close the watcher when the receiver
-// no longer needs updates. Register and Observe remain setup-time calls and are not
-// added to an existing watch.
+// no longer needs updates; stopping the server does not close existing watchers.
+// Register and Observe remain setup-time calls and are not added to an existing
+// watch.
 func (s *Server) Watch(kind string) watcher.Subscription {
 	sub := &subscription{
 		updates: make(chan error, 1),

--- a/server/service.go
+++ b/server/service.go
@@ -33,6 +33,9 @@ func NewService() *Service {
 
 // Service maintains probes, subscribers, and observers for a single service.
 //
+// Use NewService to create a Service; the zero value is not initialized for
+// registration.
+//
 // Register and Observe are setup-time calls. Start begins running all probes,
 // waits for their initial checks, and fan-outs their ticks to subscribers. Start
 // and Stop are idempotent. Stop is safe before Start and preserves observers so
@@ -90,7 +93,8 @@ func (s *Service) Error(kind string) error {
 // It returns ErrObserverNotFound if kind has not been registered. The watcher
 // receives the observer's current error immediately, then receives the current
 // error again after each matching probe tick is processed. Close the watcher
-// when the receiver no longer needs updates.
+// when the receiver no longer needs updates; stopping the service does not close
+// existing watchers.
 func (s *Service) Watch(kind string) (watcher.Subscription, error) {
 	observer, err := s.Observer(kind)
 	if err != nil {

--- a/subscriber/observer.go
+++ b/subscriber/observer.go
@@ -9,11 +9,12 @@ import (
 
 // NewObserver returns an Observer that tracks the latest errors for names.
 //
-// The observer starts consuming the subscriber immediately in a background
-// goroutine. The names slice is cloned and used to seed the error map with nil
-// values for all tracked probes, so the observer appears healthy until matching
-// ticks arrive. The observer trusts sub for tick filtering; pass a subscriber
-// configured with the same names when Names and Errors should stay aligned.
+// The subscriber must be non-nil. The observer starts consuming the subscriber
+// immediately in a background goroutine. The names slice is cloned and used to
+// seed the error map with nil values for all tracked probes, so the observer
+// appears healthy until matching ticks arrive. The observer trusts sub for tick
+// filtering; pass a subscriber configured with the same names when Names and
+// Errors should stay aligned.
 func NewObserver(names []string, sub *Subscriber) *Observer {
 	names = slices.Clone(names)
 	errs := make(Errors)
@@ -69,7 +70,8 @@ func (o *Observer) Names() []string {
 // The watcher receives the observer's current error immediately, then receives
 // the current error again after each matching probe tick is processed. Sends are
 // best-effort and coalesced to the latest error when the receiver is slow. Close
-// the watcher when the receiver no longer needs updates.
+// the watcher when the receiver no longer needs updates; the receive channel
+// closes when the watcher is closed, not when observation stops.
 func (o *Observer) Watch() watcher.Subscription {
 	sub := &subscription{
 		updates: make(chan error, 1),

--- a/watcher/subscription.go
+++ b/watcher/subscription.go
@@ -5,6 +5,7 @@ package watcher
 //
 // Receive returns a channel with the current error snapshot followed by future
 // snapshots. Close releases the subscription and closes the receive channel.
+// Callers should close the subscription when they no longer need updates.
 type Subscription interface {
 	Receive() <-chan error
 	Close()


### PR DESCRIPTION
## What

- Clarify README first-use guidance for asynchronous observer updates, aggregate health behavior, watcher cleanup, and HTTP redirect handling.
- Replace the end-to-end server snippet with a local example that waits for readyz watcher updates instead of reading observer state immediately after Start.
- Add GoDoc contracts for shared checker concurrency, wrapped online-check errors, non-nil collaborators, watcher lifecycle, registration preconditions, and constructor-required server/service values.

## Why

- Service authors can otherwise copy examples that report stale startup state, block watch streams indefinitely, or treat a missing observer kind as healthy without realizing setup was wrong.
- API consumers reading pkg.go.dev now see the non-obvious contracts at the constructors and interfaces they use, instead of relying on README prose alone.

## Testing

- `go test ./checker ./probe ./subscriber ./watcher ./server -run Example -count=1` - passed
- `go test ./server -run 'Test(ServerErrorJoinsObserverErrorsForKind|ServerWatchWaitsForKindStatusChange|ServerWatcherCoalescesPendingUpdates|ServiceErrorAndWatchRejectUnknownObserver)$' -count=1` - passed
- `go test ./checker -run 'Test(OnlineChecker|HTTPCheckerStatusCodes)' -count=1` - passed
- `make lint` - passed with existing gomodguard deprecation warning and 0 issues
