### PR TITLE
feat(server): fail closed for unknown observer kinds

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ import "github.com/alexfalkowski/go-health/v2/server"
   and updates as ticks arrive.
 - `server.Error(kind)` joins the current errors for every service that has an
   observer of that kind. A `nil` result means every matching observer is
-  healthy, or no service has registered that observer kind.
+  healthy; `server.ErrObserverNotFound` means no service has registered that
+  observer kind.
 - `server.Watch(kind)` streams the current error for that observer kind and
-  future tick-derived errors until the returned watcher is stopped. Validate
-  setup with `Observe` or `Observer` before exposing an aggregate endpoint so a
-  misspelled kind does not look healthy.
+  future tick-derived errors until the returned watcher is stopped. It returns
+  `server.ErrObserverNotFound` when no service has registered that observer
+  kind.
 - `server.Service` and `server.Server` keep observer instances across
   stop/start cycles, so existing observers continue receiving ticks after a
   restart.
@@ -172,7 +173,10 @@ func main() {
 		_ = s.Stop(context.Background())
 	}()
 
-	readyzWatcher := s.Watch("readyz")
+	readyzWatcher, err := s.Watch("readyz")
+	if err != nil {
+		log.Fatal(err)
+	}
 	defer readyzWatcher.Close()
 
 	if !waitForUpdate(readyzWatcher.Receive(), func(err error) bool {
@@ -367,7 +371,8 @@ The iteration order is unspecified. Collect and sort the service names if you
 need stable endpoint output, logs, or tests.
 
 When a transport needs a single answer for all services with the same observer
-kind, use `Server.Error(kind)`:
+kind, use `Server.Error(kind)`. It returns `server.ErrObserverNotFound` when no
+service has registered that kind.
 
 ```go
 if err := s.Error("readyz"); err != nil {
@@ -378,11 +383,15 @@ if err := s.Error("readyz"); err != nil {
 To avoid polling, watch the observer kind and report each update. The stream
 sends the current state first, then future tick-derived states. Close the
 watcher when the receiver is done; the receive channel closes when the watcher
-is closed, not when the server stops.
+is closed, not when the server stops. `Server.Watch` returns
+`server.ErrObserverNotFound` when no service has registered that kind.
 
 ```go
 func streamReady(ctx context.Context, s *server.Server, send func(bool) error) error {
-	watcher := s.Watch("readyz")
+	watcher, err := s.Watch("readyz")
+	if err != nil {
+		return err
+	}
 	defer watcher.Close()
 
 	for {

--- a/server/doc.go
+++ b/server/doc.go
@@ -23,7 +23,8 @@
 // Server.Error summarizes the current health for every service that registered
 // a given observer kind. Server.Watch returns a watcher for the current error
 // for that kind and future tick-derived errors so transport implementations can
-// report state updates without adding their own ticker.
+// report state updates without adding their own ticker. Unknown aggregate
+// observer kinds return ErrObserverNotFound instead of reporting healthy.
 //
 // # Example
 //

--- a/server/example_test.go
+++ b/server/example_test.go
@@ -31,7 +31,11 @@ func ExampleNewServer() {
 		_ = s.Stop(context.Background())
 	}()
 
-	watcher := s.Watch("readyz")
+	watcher, err := s.Watch("readyz")
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
 	defer watcher.Close()
 
 	fmt.Println(waitForUpdate(watcher.Receive(), func(err error) bool {

--- a/server/server.go
+++ b/server/server.go
@@ -65,9 +65,14 @@ func (s *Server) Observers(kind string) iter.Seq2[string, *subscriber.Observer] 
 // Error returns all non-nil observer errors for kind joined into one error.
 //
 // Services without kind are skipped. Each service error is annotated with the
-// service name before being joined. A nil result means every registered observer
-// for kind is currently healthy, or no service has registered kind.
+// service name before being joined. It returns ErrObserverNotFound when no
+// service has registered kind. A nil result means every registered observer for
+// kind is currently healthy.
 func (s *Server) Error(kind string) error {
+	if !s.hasObserver(kind) {
+		return ErrObserverNotFound
+	}
+
 	errs := make([]error, 0)
 	for name, observer := range s.Observers(kind) {
 		if err := observer.Error(); err != nil {
@@ -80,14 +85,19 @@ func (s *Server) Error(kind string) error {
 
 // Watch returns a watcher for current and future aggregate observer errors for kind.
 //
-// Services without kind are skipped. The watcher receives the current aggregate
-// error immediately, then receives the current aggregate error again after any
-// observer of kind receives a probe tick. Sends are best-effort and coalesced to
-// the latest error when the receiver is slow. Close the watcher when the receiver
-// no longer needs updates; stopping the server does not close existing watchers.
+// Services without kind are skipped. It returns ErrObserverNotFound when no
+// service has registered kind. The watcher receives the current aggregate error
+// immediately, then receives the current aggregate error again after any observer
+// of kind receives a probe tick. Sends are best-effort and coalesced to the
+// latest error when the receiver is slow. Close the watcher when the receiver no
+// longer needs updates; stopping the server does not close existing watchers.
 // Register and Observe remain setup-time calls and are not added to an existing
 // watch.
-func (s *Server) Watch(kind string) watcher.Subscription {
+func (s *Server) Watch(kind string) (watcher.Subscription, error) {
+	if !s.hasObserver(kind) {
+		return nil, ErrObserverNotFound
+	}
+
 	sub := &subscription{
 		updates: make(chan error, 1),
 		server:  s,
@@ -95,16 +105,15 @@ func (s *Server) Watch(kind string) watcher.Subscription {
 	}
 	sub.start()
 
-	return sub
+	return sub, nil
 }
 
-func (s *Server) observers(kind string) []*subscriber.Observer {
-	observers := make([]*subscriber.Observer, 0)
-	for _, observer := range s.Observers(kind) {
-		observers = append(observers, observer)
+func (s *Server) hasObserver(kind string) bool {
+	for range s.Observers(kind) {
+		return true
 	}
 
-	return observers
+	return false
 }
 
 // Observer returns an observer for the service name and observer kind.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -480,6 +480,11 @@ func TestGRPCObservers(t *testing.T) {
 	}
 
 	require.Empty(t, names)
+	require.ErrorIs(t, s.Error("grpc"), server.ErrObserverNotFound)
+
+	watcher, err := s.Watch("grpc")
+	require.ErrorIs(t, err, server.ErrObserverNotFound)
+	require.Nil(t, watcher)
 }
 
 func TestServerErrorJoinsObserverErrorsForKind(t *testing.T) {
@@ -530,7 +535,8 @@ func TestServerWatchWaitsForKindStatusChange(t *testing.T) {
 	require.NoError(t, s.Observe("test", "grpc", registration.Name))
 	require.NoError(t, s.Start(t.Context()))
 
-	watcher := s.Watch("grpc")
+	watcher, err := s.Watch("grpc")
+	require.NoError(t, err)
 	defer watcher.Close()
 	updates := watcher.Receive()
 	require.NoError(t, receiveError(t, updates))
@@ -562,7 +568,8 @@ func TestServerWatcherCoalescesPendingUpdates(t *testing.T) {
 		return errors.Is(s.Error("grpc"), errNotReady)
 	}, time.Second, 10*time.Millisecond)
 
-	watcher := s.Watch("grpc")
+	watcher, err := s.Watch("grpc")
+	require.NoError(t, err)
 	updates := watcher.Receive()
 
 	watcher.Close()

--- a/server/subscription.go
+++ b/server/subscription.go
@@ -38,7 +38,7 @@ func (s *subscription) Close() {
 func (s *subscription) start() {
 	s.publish(s.snapshot())
 
-	for _, observer := range s.server.observers(s.kind) {
+	for _, observer := range s.server.Observers(s.kind) {
 		s.watch(observer)
 	}
 }


### PR DESCRIPTION
## What

- Change aggregate health lookups to return `ErrObserverNotFound` when no service has the requested observer kind.
- Update `Server.Watch` to return `(watcher.Subscription, error)` for unknown-kind failures.
- Refresh server docs, README guidance, examples, and tests for the breaking aggregate API.

## Why

- A misspelled aggregate health kind previously looked healthy because `Server.Error` returned nil and `Server.Watch` produced a healthy-looking aggregate stream when no service registered the kind.
- Failing closed makes liveness/readiness endpoint wiring mistakes visible while keeping `Observers(kind)` available for permissive enumeration.

## Testing

- `go test ./server` - passed
- `make specs` - passed
- `make lint` - passed
- `make sec` - passed
