### PR TITLE
feat(checker): send configured request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,17 @@ check := checker.NewHTTPChecker(
 )
 ```
 
+Use `checker.WithHeader` when the health endpoint requires static request
+headers:
+
+```go
+check := checker.NewHTTPChecker(
+	"https://example.com/health",
+	5*time.Second,
+	checker.WithHeader("X-Health-Token", token),
+)
+```
+
 ### 🌍 Online checker
 
 `OnlineChecker` is useful when the question is "can this process reach the

--- a/checker/doc.go
+++ b/checker/doc.go
@@ -28,9 +28,9 @@
 // expires, the resulting error matches [ErrTimeout].
 //
 // OnlineChecker uses a built-in list of connectivity endpoints unless you
-// override it with WithURLs. HTTPChecker and OnlineChecker use
-// http.DefaultTransport by default, and TCPChecker uses net.DefaultDialer by
-// default.
+// override it with WithURLs. HTTPChecker can attach static request headers with
+// WithHeader. HTTPChecker and OnlineChecker use http.DefaultTransport by
+// default, and TCPChecker uses net.DefaultDialer by default.
 //
 // # Options
 //
@@ -38,6 +38,7 @@
 // injected without wrapping the checker:
 //
 //   - WithRoundTripper customizes the HTTP transport.
+//   - WithHeader adds a static header value to HTTPChecker requests.
 //   - WithDialer customizes TCP dialing.
 //   - WithURLs replaces the OnlineChecker URL list.
 //

--- a/checker/example_test.go
+++ b/checker/example_test.go
@@ -23,6 +23,27 @@ func ExampleNewHTTPChecker() {
 	// Output: true
 }
 
+func ExampleWithHeader() {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Health-Token") != "secret" {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer upstream.Close()
+
+	check := checker.NewHTTPChecker(
+		upstream.URL,
+		time.Second,
+		checker.WithHeader("X-Health-Token", "secret"),
+	)
+
+	fmt.Println(check.Check(context.Background()) == nil)
+	// Output: true
+}
+
 func ExampleNewOnlineChecker() {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)

--- a/checker/http.go
+++ b/checker/http.go
@@ -17,13 +17,15 @@ var ErrInvalidStatusCode = errors.New("invalid status code")
 //
 // The timeout is applied to the underlying http.Client. Passing 0 uses the
 // package default of 30 seconds. Use WithRoundTripper to provide a custom
-// transport for tests or bespoke network behavior.
+// transport for tests or bespoke network behavior. Use WithHeader to attach
+// static request headers to every check.
 func NewHTTPChecker(url string, t time.Duration, opts ...Option) *HTTPChecker {
 	options := parseOptions(opts...)
 
 	return &HTTPChecker{
-		url:    url,
-		client: &http.Client{Transport: options.roundTripper, Timeout: timeout(t)},
+		url:     url,
+		headers: options.headers.Clone(),
+		client:  &http.Client{Transport: options.roundTripper, Timeout: timeout(t)},
 	}
 }
 
@@ -34,8 +36,9 @@ func NewHTTPChecker(url string, t time.Duration, opts ...Option) *HTTPChecker {
 // below 400 are considered healthy. Responses with status codes in the 4xx or
 // 5xx range return ErrInvalidStatusCode wrapped with context.
 type HTTPChecker struct {
-	client *http.Client
-	url    string
+	client  *http.Client
+	headers http.Header
+	url     string
 }
 
 // Check performs the HTTP GET request with the supplied context.
@@ -47,6 +50,9 @@ func (c *HTTPChecker) Check(ctx context.Context) error {
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url, http.NoBody)
 	if err != nil {
 		return fmt.Errorf("http checker: %w", err)
+	}
+	if len(c.headers) > 0 {
+		request.Header = c.headers.Clone()
 	}
 
 	response, err := c.client.Do(request)

--- a/checker/http_test.go
+++ b/checker/http_test.go
@@ -41,3 +41,25 @@ func TestHTTPCheckerStatusCodes(t *testing.T) {
 		})
 	}
 }
+
+func TestHTTPCheckerHeaders(t *testing.T) {
+	headers := make(chan http.Header, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		headers <- r.Header.Clone()
+	}))
+	t.Cleanup(upstream.Close)
+
+	check := checker.NewHTTPChecker(
+		upstream.URL,
+		time.Second,
+		checker.WithHeader("Authorization", "Bearer token"),
+		checker.WithHeader("X-Health-Check", "readyz"),
+		checker.WithHeader("X-Health-Check", "livez"),
+	)
+
+	require.NoError(t, check.Check(t.Context()))
+
+	requestHeaders := <-headers
+	require.Equal(t, "Bearer token", requestHeaders.Get("Authorization"))
+	require.Equal(t, []string{"readyz", "livez"}, requestHeaders.Values("X-Health-Check"))
+}

--- a/checker/options.go
+++ b/checker/options.go
@@ -18,6 +18,7 @@ type Option interface {
 type options struct {
 	roundTripper http.RoundTripper
 	dialer       net.Dialer
+	headers      http.Header
 	urls         []string
 }
 
@@ -31,6 +32,17 @@ func (f optionFunc) apply(o *options) {
 func WithRoundTripper(rt http.RoundTripper) Option {
 	return optionFunc(func(o *options) {
 		o.roundTripper = rt
+	})
+}
+
+// WithHeader adds a header value used by HTTPChecker.
+func WithHeader(name, value string) Option {
+	return optionFunc(func(o *options) {
+		if o.headers == nil {
+			o.headers = make(http.Header)
+		}
+
+		o.headers.Add(name, value)
 	})
 }
 


### PR DESCRIPTION
## What

- Add `checker.WithHeader` so `HTTPChecker` can send static request headers.
- Apply configured headers to each HTTP GET request and preserve multiple values from repeated `WithHeader` calls.
- Update README guidance, package GoDoc, and executable examples for the new option.

## Why

- Service authors checking protected health endpoints can use the built-in HTTP checker instead of writing a custom `RoundTripper` only to attach static headers.
- The option keeps timeout handling, status-code handling, cancellation, and server registration behavior on the existing checker path.

## Testing

- `go test ./checker` - passed; covers configured headers and repeated header values through the public checker API.
- `make specs` - passed; 93 tests including the new executable `WithHeader` example.
- `make lint` - passed; 0 issues.
- `make sec` - passed; govulncheck and Trivy reported no findings.
- `git diff --check` - passed.
