### PR TITLE
docs(readme): clarify health monitoring contracts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ Important behavior details:
 
 Most workflows go through `make`. The root `Makefile` includes:
 
+- `bin/build/make/help.mak`
 - `bin/build/make/go.mak`
 - `bin/build/make/git.mak`
 
@@ -74,6 +75,7 @@ CircleCI runs those commands before any build steps.
 ### Common commands
 
 ```sh
+make help
 make dep
 make clean-dep
 make clean-lint   # clear golangci-lint cache through the bin helper

--- a/checker/doc.go
+++ b/checker/doc.go
@@ -27,10 +27,16 @@
 // If their underlying dependency returns [context.Cause] after that timeout
 // expires, the resulting error matches [ErrTimeout].
 //
-// OnlineChecker uses a built-in list of connectivity endpoints unless you
-// override it with WithURLs. HTTPChecker can attach static request headers with
-// WithHeader. HTTPChecker and OnlineChecker use http.DefaultTransport by
-// default, and TCPChecker uses net.DefaultDialer by default.
+// OnlineChecker uses this built-in list of connectivity endpoints unless you
+// override it with WithURLs:
+//
+//   - https://google.com/generate_204
+//   - https://cp.cloudflare.com/generate_204
+//   - https://connectivity-check.ubuntu.com
+//
+// HTTPChecker can attach static request headers with WithHeader. HTTPChecker
+// and OnlineChecker use http.DefaultTransport by default, and TCPChecker uses
+// net.DefaultDialer by default.
 //
 // # Options
 //

--- a/checker/online.go
+++ b/checker/online.go
@@ -16,8 +16,11 @@ var ErrNotOnline = errors.New("not online")
 // NewOnlineChecker returns an OnlineChecker that checks whether any configured URL
 // is reachable.
 //
-// Passing 0 uses the package default timeout of 30 seconds. It uses the default
-// URL list unless overridden via WithURLs.
+// Passing 0 uses the package default timeout of 30 seconds. Without WithURLs it
+// checks:
+//   - https://google.com/generate_204
+//   - https://cp.cloudflare.com/generate_204
+//   - https://connectivity-check.ubuntu.com
 func NewOnlineChecker(t time.Duration, opts ...Option) *OnlineChecker {
 	options := parseOptions(opts...)
 

--- a/checker/options.go
+++ b/checker/options.go
@@ -55,7 +55,8 @@ func WithDialer(dialer net.Dialer) Option {
 
 // WithURLs sets the list of URLs used by OnlineChecker.
 //
-// Providing at least one URL replaces the package defaults entirely.
+// Providing at least one URL replaces the package defaults entirely. Providing
+// no URLs leaves the default connectivity endpoint list in place.
 func WithURLs(urls ...string) Option {
 	return optionFunc(func(o *options) {
 		o.urls = slices.Clone(urls)

--- a/net/doc.go
+++ b/net/doc.go
@@ -4,16 +4,4 @@
 // The package exists to decouple checker implementations from the concrete types
 // in the standard library. Callers can pass the default adapter in production or
 // provide a small fake in tests.
-//
-// # Example
-//
-//	import stdnet "net"
-//
-//	type fakeDialer struct{}
-//
-//	func (fakeDialer) DialContext(ctx context.Context, network, address string) (stdnet.Conn, error) {
-//		return nil, errors.New("dial failed")
-//	}
-//
-//	checker.NewTCPChecker("cache:6379", time.Second, checker.WithDialer(fakeDialer{}))
 package net

--- a/net/example_test.go
+++ b/net/example_test.go
@@ -1,0 +1,30 @@
+package net_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/alexfalkowski/go-health/v2/checker"
+)
+
+var errDialFailed = errors.New("dial failed")
+
+func ExampleDialer() {
+	check := checker.NewTCPChecker(
+		"cache:6379",
+		time.Second,
+		checker.WithDialer(failingDialer{}),
+	)
+
+	fmt.Println(errors.Is(check.Check(context.Background()), errDialFailed))
+	// Output: true
+}
+
+type failingDialer struct{}
+
+func (failingDialer) DialContext(context.Context, string, string) (net.Conn, error) {
+	return nil, errDialFailed
+}

--- a/server/server.go
+++ b/server/server.go
@@ -131,10 +131,12 @@ func (s *Server) Observer(name, kind string) (*subscriber.Observer, error) {
 
 // Observe registers an observer kind for the service name.
 //
-// Observe is intended for setup before Start. The observer will track the probes
-// listed in names. Repeated calls with the same service and kind are idempotent.
-// It returns ErrServiceNotFound if name has not been registered, or
-// ErrProbeNotFound if any probe name is unknown.
+// Observe is intended for setup before Start. When creating a new observer kind,
+// the observer will track the probes listed in names. Repeated calls with the
+// same service and kind are idempotent, keep the original probe set, and do not
+// validate the new names. It returns ErrServiceNotFound if name has not been
+// registered, or ErrProbeNotFound if any probe name is unknown for a new
+// observer kind.
 func (s *Server) Observe(name, kind string, names ...string) error {
 	service, ok := s.services[name]
 	if !ok {

--- a/server/service.go
+++ b/server/service.go
@@ -92,7 +92,8 @@ func (s *Service) Error(kind string) error {
 //
 // It returns ErrObserverNotFound if kind has not been registered. The watcher
 // receives the observer's current error immediately, then receives the current
-// error again after each matching probe tick is processed. Close the watcher
+// error again after each matching probe tick is processed. Sends are best-effort
+// and coalesced to the latest error when the receiver is slow. Close the watcher
 // when the receiver no longer needs updates; stopping the service does not close
 // existing watchers.
 func (s *Service) Watch(kind string) (watcher.Subscription, error) {
@@ -106,9 +107,10 @@ func (s *Service) Watch(kind string) (watcher.Subscription, error) {
 
 // Observe registers an observer kind that tracks the probes listed in names.
 //
-// Observe is intended for setup before Start. It returns an error if any probe
-// name has not been registered. Repeated calls with the same kind are idempotent
-// and keep the original probe set. Unknown probe names are reported with
+// Observe is intended for setup before Start. When creating a new observer kind,
+// it returns an error if any probe name has not been registered. Repeated calls
+// with the same kind are idempotent, keep the original probe set, and do not
+// validate the new names. Unknown probe names for a new kind are reported with
 // ErrProbeNotFound; multiple unknown probes are joined into one error.
 func (s *Service) Observe(kind string, names ...string) error {
 	_, ok := s.observers[kind]

--- a/sql/doc.go
+++ b/sql/doc.go
@@ -2,15 +2,4 @@
 //
 // The package keeps the checker layer independent from *database/sql while still
 // making it easy to adapt standard library types.
-//
-// # Example
-//
-//	import "database/sql"
-//
-//	var db *sql.DB // initialized by your application
-//	check := checker.NewDBChecker(db, 5*time.Second)
-//
-//	if err := check.Check(context.Background()); err != nil {
-//		log.Printf("database unhealthy: %v", err)
-//	}
 package sql

--- a/sql/example_test.go
+++ b/sql/example_test.go
@@ -1,0 +1,25 @@
+package sql_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/alexfalkowski/go-health/v2/checker"
+)
+
+var errPingFailed = errors.New("ping failed")
+
+func Example() {
+	check := checker.NewDBChecker(failingPinger{}, time.Second)
+
+	fmt.Println(errors.Is(check.Check(context.Background()), errPingFailed))
+	// Output: true
+}
+
+type failingPinger struct{}
+
+func (failingPinger) PingContext(context.Context) error {
+	return errPingFailed
+}

--- a/watcher/subscription.go
+++ b/watcher/subscription.go
@@ -4,8 +4,11 @@ package watcher
 // Subscription receives current and future health error snapshots.
 //
 // Receive returns a channel with the current error snapshot followed by future
-// snapshots. Close releases the subscription and closes the receive channel.
-// Callers should close the subscription when they no longer need updates.
+// snapshots. Subscriptions expose state snapshots, not an event log; concrete
+// implementations may coalesce pending updates to the latest error when the
+// receiver is slow. Close releases the subscription and closes the receive
+// channel. Callers should close the subscription when they no longer need
+// updates.
 type Subscription interface {
 	Receive() <-chan error
 	Close()


### PR DESCRIPTION
## What

- Document the concrete OnlineChecker default endpoint list and the empty WithURLs fallback in GoDoc.
- Clarify observer watch delivery as latest-state snapshots that may coalesce when receivers are slow.
- Clarify Observe idempotency so repeated calls keep the original probe set and do not validate replacement names.
- Move adapter package usage snippets into executable net and sql examples, and document the root help Make fragment.

## Why

- Makes pkg.go.dev and maintainer guidance match the implementation contracts readers rely on before configuring egress, health transports, observer lifecycles, or local commands.
- Replaces incomplete copy-only snippets with examples that compile under the repository test harness.

## Testing

- `go test ./checker ./probe ./subscriber ./server ./watcher ./net ./sql -run '^Example'` - passed
- `go doc -all ./checker` - passed
- `go doc -all ./server` - passed
- `go doc -all ./watcher` - passed
- `go test ./net ./sql -run '^Example' -v` - passed
- `make help` - passed
- `make lint` - passed
- `make specs` - passed
