### PR TITLE
test(specs): add parallel execution and fuzz coverage

### DIFF
--- a/checker/context_test.go
+++ b/checker/context_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestCheckersReturnCanceledContext(t *testing.T) {
+	t.Parallel()
+
 	errNotReady := errors.New("not ready")
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
@@ -33,6 +35,8 @@ func TestCheckersReturnCanceledContext(t *testing.T) {
 
 	for _, tt := range checkers {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			err := tt.check.Check(ctx)
 
 			require.ErrorIs(t, err, context.Canceled)

--- a/checker/fuzz_test.go
+++ b/checker/fuzz_test.go
@@ -1,0 +1,134 @@
+package checker_test
+
+import (
+	"errors"
+	"net/http"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/alexfalkowski/go-health/v2/checker"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzHTTPCheckerRequestAndStatus(f *testing.F) {
+	f.Add("https://example.com/health", 200, "X-Health-Check", "readyz")
+	f.Add("https://example.com/health", 204, "Authorization", "Bearer token")
+	f.Add("https://example.com/health", 399, "X-Health-Check", "livez")
+	f.Add("https://example.com/health", 400, "X-Health-Check", "readyz")
+	f.Add("https://example.com/health", 500, "X-Health-Check", "readyz")
+	f.Add("://bad-url", 200, "X-Health-Check", "readyz")
+	f.Add("", 200, "X-Health-Check", "readyz")
+	f.Add("https://example.com/health", 200, "", "readyz")
+
+	f.Fuzz(func(t *testing.T, url string, status int, headerName, headerValue string) {
+		transport := &recordingRoundTripper{status: status}
+		check := checker.NewHTTPChecker(
+			url,
+			time.Second,
+			checker.WithRoundTripper(transport),
+			checker.WithHeader(headerName, headerValue),
+		)
+
+		err := check.Check(t.Context())
+
+		if transport.request == nil {
+			require.Error(t, err)
+			require.NotErrorIs(t, err, checker.ErrInvalidStatusCode)
+			return
+		}
+
+		require.Equal(t, http.MethodGet, transport.request.Method)
+		if headerName != "" {
+			require.Equal(t, headerValue, transport.request.Header.Get(headerName))
+		}
+		if status >= http.StatusBadRequest {
+			require.ErrorIs(t, err, checker.ErrInvalidStatusCode)
+			return
+		}
+		require.NoError(t, err)
+	})
+}
+
+func FuzzOnlineCheckerURLsAndStatuses(f *testing.F) {
+	f.Add("https://example.com/first", 200, "https://example.com/second", 500, "://bad-url", 404)
+	f.Add("https://example.com/first", 204, "https://example.com/second", 404, "https://example.com/third", 500)
+	f.Add("https://example.com/first", 500, "https://example.com/second", 404, "https://example.com/third", 399)
+	f.Add("://bad-url", 200, "https://example.com/second", 500, "https://example.com/third", 500)
+	f.Add("", 200, "https://example.com/second", 204, "https://example.com/third", 500)
+
+	f.Fuzz(func(t *testing.T, url1 string, status1 int, url2 string, status2 int, url3 string, status3 int) {
+		transport := &statusRoundTripper{
+			statuses: map[string]int{
+				url1: status1,
+				url2: status2,
+				url3: status3,
+			},
+		}
+		check := checker.NewOnlineChecker(
+			time.Second,
+			checker.WithRoundTripper(transport),
+			checker.WithURLs(url1, url2, url3),
+		)
+
+		err := check.Check(t.Context())
+
+		if transport.healthy() {
+			require.NoError(t, err)
+			return
+		}
+		require.ErrorIs(t, err, checker.ErrNotOnline)
+	})
+}
+
+type recordingRoundTripper struct {
+	request *http.Request
+	status  int
+}
+
+func (t *recordingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.request = req.Clone(req.Context())
+	t.request.Header = req.Header.Clone()
+
+	return response(req, t.status), nil
+}
+
+type statusRoundTripper struct {
+	statuses map[string]int
+	mux      sync.Mutex
+	online   bool
+}
+
+func (t *statusRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	status, ok := t.statuses[req.URL.String()]
+	if !ok {
+		return nil, errors.New("unexpected URL")
+	}
+	if onlineStatus(status) {
+		t.mux.Lock()
+		t.online = true
+		t.mux.Unlock()
+	}
+
+	return response(req, status), nil
+}
+
+func (t *statusRoundTripper) healthy() bool {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+
+	return t.online
+}
+
+func response(req *http.Request, status int) *http.Response {
+	return &http.Response{
+		StatusCode: status,
+		Body:       http.NoBody,
+		Header:     make(http.Header),
+		Request:    req,
+	}
+}
+
+func onlineStatus(status int) bool {
+	return status == http.StatusOK || status == http.StatusNoContent
+}

--- a/checker/http_test.go
+++ b/checker/http_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestHTTPCheckerStatusCodes(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name              string
 		status            int
@@ -24,6 +26,8 @@ func TestHTTPCheckerStatusCodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tt.status)
 			}))
@@ -43,6 +47,8 @@ func TestHTTPCheckerStatusCodes(t *testing.T) {
 }
 
 func TestHTTPCheckerHeaders(t *testing.T) {
+	t.Parallel()
+
 	headers := make(chan http.Header, 1)
 	upstream := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
 		headers <- r.Header.Clone()

--- a/checker/online_test.go
+++ b/checker/online_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestOnlineCheckerClonesURLs(t *testing.T) {
+	t.Parallel()
+
 	healthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusNoContent)
 	}))
@@ -62,6 +64,8 @@ func TestOnlineCheckerReturnsOnFirstHealthyURL(t *testing.T) {
 }
 
 func TestOnlineCheckerStatusCodes(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name          string
 		status        int
@@ -75,6 +79,8 @@ func TestOnlineCheckerStatusCodes(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(tt.status)
 			}))
@@ -94,6 +100,8 @@ func TestOnlineCheckerStatusCodes(t *testing.T) {
 }
 
 func TestOnlineCheckerReturnsNotOnlineWhenEveryURLFails(t *testing.T) {
+	t.Parallel()
+
 	unhealthy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))

--- a/checker/tcp_test.go
+++ b/checker/tcp_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestTCPCheckerZeroTimeoutUsesDefault(t *testing.T) {
+	t.Parallel()
+
 	dialer := &recordingDialer{}
 	check := checker.NewTCPChecker("example:80", 0, checker.WithDialer(dialer))
 
@@ -20,6 +22,8 @@ func TestTCPCheckerZeroTimeoutUsesDefault(t *testing.T) {
 }
 
 func TestTCPCheckerClosesSuccessfulConnection(t *testing.T) {
+	t.Parallel()
+
 	dialer := &recordingDialer{}
 	check := checker.NewTCPChecker("example:80", time.Second, checker.WithDialer(dialer))
 

--- a/probe/probe_test.go
+++ b/probe/probe_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestStopWithoutStartDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
 	p := probe.NewProbe("noop", 10*time.Millisecond, checker.NewNoopChecker())
 
 	require.NotPanics(t, func() {
@@ -77,6 +79,8 @@ func TestConcurrentStartWaitsForInitialCheck(t *testing.T) {
 }
 
 func TestStartWithCanceledContextReturnsContextError(t *testing.T) {
+	t.Parallel()
+
 	p := probe.NewProbe("noop", time.Hour, checker.NewNoopChecker())
 	ctx, cancel := context.WithCancel(t.Context())
 	cancel()
@@ -149,6 +153,8 @@ func TestStopReturnsContextError(t *testing.T) {
 }
 
 func TestStartWithInvalidPeriodReturnsErrorTick(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name   string
 		period time.Duration
@@ -159,6 +165,8 @@ func TestStartWithInvalidPeriodReturnsErrorTick(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			p := probe.NewProbe("noop", tt.period, checker.NewNoopChecker())
 
 			require.NotPanics(t, func() {

--- a/server/benchmark_test.go
+++ b/server/benchmark_test.go
@@ -1,0 +1,36 @@
+package server_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alexfalkowski/go-health/v2/checker"
+	testsubscriber "github.com/alexfalkowski/go-health/v2/internal/test/subscriber"
+	"github.com/alexfalkowski/go-health/v2/server"
+)
+
+func BenchmarkValidHTTPChecker(b *testing.B) {
+	b.ReportAllocs()
+
+	s := server.NewServer()
+	defer func() { _ = s.Stop(context.Background()) }()
+
+	checker := checker.NewHTTPChecker("https://www.google.com/", period)
+
+	r := server.NewRegistration("google", period, checker)
+	s.Register("test", r)
+
+	_ = s.Observe("test", "livez", r.Name)
+	ob, _ := s.Observer("test", "livez")
+
+	_ = s.Start(b.Context())
+	testsubscriber.WaitObserverNoError(b, ob)
+
+	b.ResetTimer()
+
+	for b.Loop() {
+		if err := ob.Error(); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/server/fuzz_test.go
+++ b/server/fuzz_test.go
@@ -1,0 +1,61 @@
+package server_test
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/alexfalkowski/go-health/v2/checker"
+	"github.com/alexfalkowski/go-health/v2/server"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzServiceObserveValidation(f *testing.F) {
+	f.Add("livez", "db", "cache", "db", "cache", "ignored")
+	f.Add("readyz", "db", "cache", "db", "missing", "cache")
+	f.Add("", "", "cache", "", "cache", "missing")
+	f.Add("livez", "duplicate", "duplicate", "duplicate", "missing", "duplicate")
+
+	f.Fuzz(func(t *testing.T, kind string, reg1 string, reg2 string, obs1 string, obs2 string, replacement string) {
+		s := server.NewService()
+		t.Cleanup(func() { _ = s.Stop(context.Background()) })
+
+		s.Register(
+			server.NewRegistration(reg1, time.Hour, checker.NewNoopChecker()),
+			server.NewRegistration(reg2, time.Hour, checker.NewNoopChecker()),
+		)
+
+		err := s.Observe(kind, obs1, obs2)
+		allObservedRegistered := containsAll([]string{reg1, reg2}, obs1, obs2)
+		if !allObservedRegistered {
+			require.ErrorIs(t, err, server.ErrProbeNotFound)
+
+			_, observerErr := s.Observer(kind)
+			require.ErrorIs(t, observerErr, server.ErrObserverNotFound)
+			return
+		}
+		require.NoError(t, err)
+
+		observer, err := s.Observer(kind)
+		require.NoError(t, err)
+		originalNames := observer.Names()
+
+		require.NoError(t, s.Observe(kind, replacement))
+
+		sameObserver, err := s.Observer(kind)
+		require.NoError(t, err)
+		require.Same(t, observer, sameObserver)
+		require.Equal(t, originalNames, sameObserver.Names())
+	})
+}
+
+func containsAll(names []string, observed ...string) bool {
+	for _, name := range observed {
+		if !slices.Contains(names, name) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -52,6 +52,8 @@ func TestDoubleStart(t *testing.T) {
 }
 
 func TestStartWithCanceledContextReturnsContextError(t *testing.T) {
+	t.Parallel()
+
 	s := server.NewServer()
 	registration := server.NewRegistration("noop", time.Hour, checker.NewNoopChecker())
 	s.Register("test", registration)
@@ -173,6 +175,8 @@ func TestInvalidURLHTTPChecker(t *testing.T) {
 }
 
 func TestMalformedURLHTTPChecker(t *testing.T) {
+	t.Parallel()
+
 	s := server.NewServer()
 	defer func() { _ = s.Stop(context.Background()) }()
 
@@ -221,6 +225,8 @@ func TestTimeoutHTTPChecker(t *testing.T) {
 }
 
 func TestInvalidPeriod(t *testing.T) {
+	t.Parallel()
+
 	s := server.NewServer()
 	defer func() { _ = s.Stop(context.Background()) }()
 
@@ -418,6 +424,8 @@ func TestOneInvalidObserver(t *testing.T) {
 }
 
 func TestObserveUnknownProbeNames(t *testing.T) {
+	t.Parallel()
+
 	s := server.NewServer()
 	defer func() { _ = s.Stop(context.Background()) }()
 
@@ -437,6 +445,8 @@ func TestObserveUnknownProbeNames(t *testing.T) {
 }
 
 func TestLivezObservers(t *testing.T) {
+	t.Parallel()
+
 	s := server.NewServer()
 	defer func() { _ = s.Stop(context.Background()) }()
 
@@ -460,6 +470,8 @@ func TestLivezObservers(t *testing.T) {
 }
 
 func TestGRPCObservers(t *testing.T) {
+	t.Parallel()
+
 	s := server.NewServer()
 	defer func() { _ = s.Stop(context.Background()) }()
 
@@ -488,6 +500,8 @@ func TestGRPCObservers(t *testing.T) {
 }
 
 func TestServerErrorJoinsObserverErrorsForKind(t *testing.T) {
+	t.Parallel()
+
 	s := server.NewServer()
 	t.Cleanup(func() { _ = s.Stop(context.Background()) })
 
@@ -525,6 +539,8 @@ func TestServerErrorJoinsObserverErrorsForKind(t *testing.T) {
 }
 
 func TestServerWatchWaitsForKindStatusChange(t *testing.T) {
+	t.Parallel()
+
 	s := server.NewServer()
 	t.Cleanup(func() { _ = s.Stop(context.Background()) })
 
@@ -553,6 +569,8 @@ func TestServerWatchWaitsForKindStatusChange(t *testing.T) {
 }
 
 func TestServerWatcherCoalescesPendingUpdates(t *testing.T) {
+	t.Parallel()
+
 	s := server.NewServer()
 	t.Cleanup(func() { _ = s.Stop(context.Background()) })
 
@@ -578,6 +596,8 @@ func TestServerWatcherCoalescesPendingUpdates(t *testing.T) {
 }
 
 func TestInvalidObservers(t *testing.T) {
+	t.Parallel()
+
 	s := server.NewServer()
 	defer func() { _ = s.Stop(context.Background()) }()
 
@@ -639,32 +659,6 @@ func receiveClosed(t *testing.T, updates <-chan error) {
 		case <-timeout:
 			require.Fail(t, "timed out waiting for observer updates to close")
 			return
-		}
-	}
-}
-
-func BenchmarkValidHTTPChecker(b *testing.B) {
-	b.ReportAllocs()
-
-	s := server.NewServer()
-	defer func() { _ = s.Stop(context.Background()) }()
-
-	checker := checker.NewHTTPChecker("https://www.google.com/", period)
-
-	r := server.NewRegistration("google", period, checker)
-	s.Register("test", r)
-
-	_ = s.Observe("test", "livez", r.Name)
-	ob, _ := s.Observer("test", "livez")
-
-	_ = s.Start(b.Context())
-	testsubscriber.WaitObserverNoError(b, ob)
-
-	b.ResetTimer()
-
-	for b.Loop() {
-		if err := ob.Error(); err != nil {
-			b.Fatal(err)
 		}
 	}
 }

--- a/server/service_test.go
+++ b/server/service_test.go
@@ -38,6 +38,8 @@ func TestServiceStartStopGuards(t *testing.T) {
 }
 
 func TestServiceObserveRejectsUnknownProbes(t *testing.T) {
+	t.Parallel()
+
 	s := server.NewService()
 
 	registration := server.NewRegistration("noop", 10*time.Millisecond, checker.NewNoopChecker())
@@ -51,6 +53,8 @@ func TestServiceObserveRejectsUnknownProbes(t *testing.T) {
 }
 
 func TestServiceObserveKeepsOriginalProbeSetForExistingKind(t *testing.T) {
+	t.Parallel()
+
 	s := server.NewService()
 
 	first := server.NewRegistration("first", time.Hour, checker.NewNoopChecker())
@@ -94,6 +98,8 @@ func TestServiceErrorReturnsObserverError(t *testing.T) {
 }
 
 func TestServiceErrorAndWatchRejectUnknownObserver(t *testing.T) {
+	t.Parallel()
+
 	s := server.NewService()
 
 	require.ErrorIs(t, s.Error("readyz"), server.ErrObserverNotFound)

--- a/subscriber/fuzz_test.go
+++ b/subscriber/fuzz_test.go
@@ -1,0 +1,68 @@
+package subscriber_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/alexfalkowski/go-health/v2/subscriber"
+	"github.com/stretchr/testify/require"
+)
+
+func FuzzErrorsAggregationAndCopy(f *testing.F) {
+	f.Add("db", true, "cache", true, "search", false)
+	f.Add("", true, "cache", false, "search", true)
+	f.Add("db:primary", true, "cache\nprimary", true, "search primary", true)
+	f.Add("duplicate", true, "duplicate", false, "duplicate", true)
+
+	f.Fuzz(func(t *testing.T, name1 string, failed1 bool, name2 string, failed2 bool, name3 string, failed3 bool) {
+		errs := subscriber.Errors{
+			name1: errorFor("first", failed1),
+			name2: errorFor("second", failed2),
+			name3: errorFor("third", failed3),
+		}
+		want := map[string]error{
+			name1: errs[name1],
+			name2: errs[name2],
+			name3: errs[name3],
+		}
+
+		err := errs.Error()
+		for name, wantErr := range want {
+			if wantErr == nil {
+				continue
+			}
+
+			require.ErrorIs(t, err, wantErr)
+			require.ErrorContains(t, err, name+":")
+		}
+		if noFailures(want) {
+			require.NoError(t, err)
+		}
+
+		copied := errs.Errors()
+		copied[name1] = nil
+		delete(copied, name2)
+
+		for name, wantErr := range want {
+			require.ErrorIs(t, errs[name], wantErr)
+		}
+	})
+}
+
+func errorFor(name string, failed bool) error {
+	if failed {
+		return errors.New(name + " failed")
+	}
+
+	return nil
+}
+
+func noFailures(errs map[string]error) bool {
+	for _, err := range errs {
+		if err != nil {
+			return false
+		}
+	}
+
+	return true
+}

--- a/subscriber/subscriber_test.go
+++ b/subscriber/subscriber_test.go
@@ -42,6 +42,8 @@ func TestCloseWhileSendingDoesNotPanic(t *testing.T) {
 }
 
 func TestSubscriberClonesNames(t *testing.T) {
+	t.Parallel()
+
 	names := []string{"a"}
 	s := subscriber.NewSubscriber(names)
 
@@ -66,6 +68,8 @@ func TestSubscriberClonesNames(t *testing.T) {
 }
 
 func TestSubscriberDropsTicksWhenBufferIsFull(t *testing.T) {
+	t.Parallel()
+
 	s := subscriber.NewSubscriber([]string{"a"})
 	first := probe.NewTick("a", nil)
 	second := probe.NewTick("a", nil)
@@ -93,6 +97,8 @@ func TestSubscriberDropsTicksWhenBufferIsFull(t *testing.T) {
 }
 
 func TestObserverStartsWithNilErrorsForTrackedNames(t *testing.T) {
+	t.Parallel()
+
 	s := subscriber.NewSubscriber([]string{dbProbeName, cacheProbeName})
 	ob := subscriber.NewObserver([]string{dbProbeName, cacheProbeName}, s)
 	s.Close()
@@ -108,6 +114,8 @@ func TestObserverStartsWithNilErrorsForTrackedNames(t *testing.T) {
 }
 
 func TestObserverErrorsReturnsCopy(t *testing.T) {
+	t.Parallel()
+
 	s := subscriber.NewSubscriber([]string{dbProbeName, cacheProbeName})
 	ob := subscriber.NewObserver([]string{dbProbeName, cacheProbeName}, s)
 	errDB := errors.New("db failed")
@@ -183,6 +191,8 @@ func TestObserverWatchSendsTicksWithoutStatusChange(t *testing.T) {
 }
 
 func TestErrorsErrorJoinsAnnotatedErrors(t *testing.T) {
+	t.Parallel()
+
 	errDB := errors.New("db failed")
 	errCache := errors.New("cache failed")
 	err := subscriber.Errors{


### PR DESCRIPTION
## What

- Added parallel execution to isolated checker, probe, subscriber, and server tests while leaving live-network and timing-heavy lifecycle coverage serial.
- Added fuzz targets for checker HTTP/online behavior, subscriber error aggregation/copy behavior, and service observer validation.
- Moved the existing server benchmark into a dedicated benchmark test file.

## Why

- Improves local and CI feedback by allowing more independent checks to run concurrently.
- Adds input-driven coverage around public health-check and observer setup behavior without relying on external services.
- Keeps benchmark and fuzz entrypoints in the repository's expected Go test file layout.

## Testing

- `go test ./checker ./probe ./subscriber ./server` - passed
- `make specs` - passed
- `make lint` - passed with the existing gomodguard deprecation warning
- `make fuzz package=checker name=FuzzHTTPCheckerRequestAndStatus fuzztime=2s` - passed
- `make fuzz package=checker name=FuzzOnlineCheckerURLsAndStatuses fuzztime=2s` - passed
- `make fuzz package=subscriber name=FuzzErrorsAggregationAndCopy fuzztime=2s` - passed
- `make fuzz package=server name=FuzzServiceObserveValidation fuzztime=2s` - passed
- `git diff --check` - passed

AI-assisted-by: [Codex](https://openai.com/codex/)
