### PR TITLE
test(internal): align fuzz rationale and benchmark workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,8 @@ make lint
 make fix-lint     # auto-fix what can be fixed
 make sec
 make specs
+make benchmark    # defaults to package=server; set package=... to override
+make fuzz package=checker name=FuzzHTTPCheckerRequestAndStatus
 make coverage     # generate HTML and function coverage summaries
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+REQUESTED_PACKAGE := $(value package)
+
 include bin/build/make/help.mak
 include bin/build/make/go.mak
 include bin/build/make/git.mak
+
+ifeq ($(REQUESTED_PACKAGE),)
+benchmark benchmark-pprof: package = server
+endif

--- a/README.md
+++ b/README.md
@@ -438,6 +438,7 @@ make dep
 make lint
 make sec
 make specs
+make benchmark # defaults to the server package; set package=... to override
 make coverage
 ```
 

--- a/checker/fuzz_test.go
+++ b/checker/fuzz_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func FuzzHTTPCheckerRequestAndStatus(f *testing.F) {
+	// Fuzz URL, status, and header combinations because HTTPChecker owns request construction and status handling.
 	f.Add("https://example.com/health", 200, "X-Health-Check", "readyz")
 	f.Add("https://example.com/health", 204, "Authorization", "Bearer token")
 	f.Add("https://example.com/health", 399, "X-Health-Check", "livez")
@@ -51,6 +52,7 @@ func FuzzHTTPCheckerRequestAndStatus(f *testing.F) {
 }
 
 func FuzzOnlineCheckerURLsAndStatuses(f *testing.F) {
+	// Fuzz URL and status combinations because OnlineChecker owns fallback across caller-supplied endpoints.
 	f.Add("https://example.com/first", 200, "https://example.com/second", 500, "://bad-url", 404)
 	f.Add("https://example.com/first", 204, "https://example.com/second", 404, "https://example.com/third", 500)
 	f.Add("https://example.com/first", 500, "https://example.com/second", 404, "https://example.com/third", 399)

--- a/server/benchmark_test.go
+++ b/server/benchmark_test.go
@@ -3,34 +3,30 @@ package server_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/alexfalkowski/go-health/v2/checker"
-	testsubscriber "github.com/alexfalkowski/go-health/v2/internal/test/subscriber"
 	"github.com/alexfalkowski/go-health/v2/server"
+	"github.com/stretchr/testify/require"
 )
 
-func BenchmarkValidHTTPChecker(b *testing.B) {
+func BenchmarkServerErrorHealthyObserver(b *testing.B) {
+	// Benchmark the public aggregate health read path with initialized observer state.
 	b.ReportAllocs()
 
 	s := server.NewServer()
-	defer func() { _ = s.Stop(context.Background()) }()
-
-	checker := checker.NewHTTPChecker("https://www.google.com/", period)
-
-	r := server.NewRegistration("google", period, checker)
-	s.Register("test", r)
-
-	_ = s.Observe("test", "livez", r.Name)
-	ob, _ := s.Observer("test", "livez")
-
-	_ = s.Start(b.Context())
-	testsubscriber.WaitObserverNoError(b, ob)
+	registration := server.NewRegistration("noop", time.Hour, checker.NewNoopChecker())
+	s.Register("test", registration)
+	require.NoError(b, s.Observe("test", "livez", registration.Name))
 
 	b.ResetTimer()
 
 	for b.Loop() {
-		if err := ob.Error(); err != nil {
-			b.Fatal(err)
+		if err := s.Error("livez"); err != nil {
+			require.NoError(b, err)
 		}
 	}
+
+	b.StopTimer()
+	require.NoError(b, s.Stop(context.Background()))
 }

--- a/server/fuzz_test.go
+++ b/server/fuzz_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func FuzzServiceObserveValidation(f *testing.F) {
+	// Fuzz registration and observer names because Service owns observer validation and idempotent probe sets.
 	f.Add("livez", "db", "cache", "db", "cache", "ignored")
 	f.Add("readyz", "db", "cache", "db", "missing", "cache")
 	f.Add("", "", "cache", "", "cache", "missing")

--- a/subscriber/fuzz_test.go
+++ b/subscriber/fuzz_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func FuzzErrorsAggregationAndCopy(f *testing.F) {
+	// Fuzz names and failure states because Errors owns named aggregation and defensive map copies.
 	f.Add("db", true, "cache", true, "search", false)
 	f.Add("", true, "cache", false, "search", true)
 	f.Add("db:primary", true, "cache\nprimary", true, "search primary", true)


### PR DESCRIPTION
## What

- Add a repo-local benchmark default so `make benchmark` runs the `server` package when no package is provided, while preserving explicit package overrides.
- Rework the server benchmark to measure the deterministic public aggregate health read path with initialized observer state and `require` checks.
- Document the benchmark and fuzz command paths, and add concrete rationale comments to each fuzz target.

## Why

- The shared benchmark target defaults to the module root, but this repository has no root Go package, so plain `make benchmark` failed before reaching the existing benchmark.
- The previous benchmark name and setup implied HTTP checker performance while the timed loop measured observer error reads after live network setup.
- The updated shared Go guidance expects benchmark and fuzz entrypoints to state a repository-owned performance question or input/state-space risk.

## Testing

- `make specs` - passed
- `make lint` - passed with 0 issues and the existing gomodguard deprecation warning
- `make benchmark benchtime=1x` - passed
- `make benchmark package=checker benchtime=1x` - passed
- `make fuzz package=checker name=FuzzHTTPCheckerRequestAndStatus fuzztime=1s` - passed
- `make fuzz package=checker name=FuzzOnlineCheckerURLsAndStatuses fuzztime=1s` - passed
- `make fuzz package=server name=FuzzServiceObserveValidation fuzztime=1s` - passed
- `make fuzz package=subscriber name=FuzzErrorsAggregationAndCopy fuzztime=1s` - passed
