### PR TITLE
test(internal): surface fuzz and benchmark entrypoints

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ jobs:
             - ~/.cache/golangci-lint
       - run: make sec
       - run: make specs
+      - run: make benchmarks
       - save_cache:
           name: save go build cache
           key: go-health-go-build-cache-{{ checksum "go.sum" }}-{{ checksum "~/.go-version" }}-{{ checksum ".source-key" }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,9 @@ make fix-lint     # auto-fix what can be fixed
 make sec
 make specs
 make benchmark    # defaults to package=server; set package=... to override
+make benchmarks   # aggregate benchmark target
 make fuzz package=checker name=FuzzHTTPCheckerRequestAndStatus
+make fuzz-smoke   # bounded fuzz smoke tests; set fuzztime=... to override
 make coverage     # generate HTML and function coverage summaries
 ```
 
@@ -134,8 +136,9 @@ The main CircleCI `build` job does the following, in order:
 7. Runs `make lint`.
 8. Runs `make sec`.
 9. Runs `make specs`.
-10. Runs `make coverage`.
-11. Uploads coverage and stores test reports.
+10. Runs `make benchmarks`.
+11. Runs `make coverage`.
+12. Uploads coverage and stores test reports.
 
 There are also `sync`, `version`, and `wait-all` jobs in `.circleci/config.yml`.
 

--- a/Makefile
+++ b/Makefile
@@ -7,3 +7,22 @@ include bin/build/make/git.mak
 ifeq ($(REQUESTED_PACKAGE),)
 benchmark benchmark-pprof: package = server
 endif
+
+# Run all the benchmarks.
+benchmarks: server-benchmarks
+
+server-benchmarks:
+	@$(MAKE) package=server benchtime=100x benchmark
+
+# Run bounded fuzz smoke tests. Set fuzztime=<duration> to override the default 1s per target.
+fuzz-smoke: checker-fuzz subscriber-fuzz server-fuzz
+
+checker-fuzz:
+	@$(MAKE) package=checker name=FuzzHTTPCheckerRequestAndStatus fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=checker name=FuzzOnlineCheckerURLsAndStatuses fuzztime=$(or $(fuzztime),1s) fuzz
+
+subscriber-fuzz:
+	@$(MAKE) package=subscriber name=FuzzErrorsAggregationAndCopy fuzztime=$(or $(fuzztime),1s) fuzz
+
+server-fuzz:
+	@$(MAKE) package=server name=FuzzServiceObserveValidation fuzztime=$(or $(fuzztime),1s) fuzz

--- a/README.md
+++ b/README.md
@@ -438,8 +438,25 @@ make dep
 make lint
 make sec
 make specs
-make benchmark # defaults to the server package; set package=... to override
 make coverage
+```
+
+Benchmarks:
+
+```sh
+make benchmark # defaults to the server package; set package=... to override
+make benchmarks
+make server-benchmarks
+```
+
+Fuzz smoke tests:
+
+```sh
+make fuzz-smoke
+make checker-fuzz
+make subscriber-fuzz
+make server-fuzz
+make package=checker name=FuzzHTTPCheckerRequestAndStatus fuzztime=10s fuzz
 ```
 
 Local test notes:

--- a/checker/fuzz_test.go
+++ b/checker/fuzz_test.go
@@ -11,8 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzHTTPCheckerRequestAndStatus explores URL, status, and header combinations because HTTPChecker owns
+// request construction and status handling.
 func FuzzHTTPCheckerRequestAndStatus(f *testing.F) {
-	// Fuzz URL, status, and header combinations because HTTPChecker owns request construction and status handling.
 	f.Add("https://example.com/health", 200, "X-Health-Check", "readyz")
 	f.Add("https://example.com/health", 204, "Authorization", "Bearer token")
 	f.Add("https://example.com/health", 399, "X-Health-Check", "livez")
@@ -51,8 +52,9 @@ func FuzzHTTPCheckerRequestAndStatus(f *testing.F) {
 	})
 }
 
+// FuzzOnlineCheckerURLsAndStatuses explores URL and status combinations because OnlineChecker owns
+// fallback across caller-supplied endpoints.
 func FuzzOnlineCheckerURLsAndStatuses(f *testing.F) {
-	// Fuzz URL and status combinations because OnlineChecker owns fallback across caller-supplied endpoints.
 	f.Add("https://example.com/first", 200, "https://example.com/second", 500, "://bad-url", 404)
 	f.Add("https://example.com/first", 204, "https://example.com/second", 404, "https://example.com/third", 500)
 	f.Add("https://example.com/first", 500, "https://example.com/second", 404, "https://example.com/third", 399)

--- a/server/benchmark_test.go
+++ b/server/benchmark_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// BenchmarkServerErrorHealthyObserver measures the public aggregate health read path with initialized
+// observer state.
 func BenchmarkServerErrorHealthyObserver(b *testing.B) {
-	// Benchmark the public aggregate health read path with initialized observer state.
 	b.ReportAllocs()
 
 	s := server.NewServer()

--- a/server/fuzz_test.go
+++ b/server/fuzz_test.go
@@ -11,8 +11,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzServiceObserveValidation explores registration and observer names because Service owns observer
+// validation and idempotent probe sets.
 func FuzzServiceObserveValidation(f *testing.F) {
-	// Fuzz registration and observer names because Service owns observer validation and idempotent probe sets.
 	f.Add("livez", "db", "cache", "db", "cache", "ignored")
 	f.Add("readyz", "db", "cache", "db", "missing", "cache")
 	f.Add("", "", "cache", "", "cache", "missing")

--- a/subscriber/fuzz_test.go
+++ b/subscriber/fuzz_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// FuzzErrorsAggregationAndCopy explores names and failure states because Errors owns named aggregation
+// and defensive map copies.
 func FuzzErrorsAggregationAndCopy(f *testing.F) {
-	// Fuzz names and failure states because Errors owns named aggregation and defensive map copies.
 	f.Add("db", true, "cache", true, "search", false)
 	f.Add("", true, "cache", false, "search", true)
 	f.Add("db:primary", true, "cache\nprimary", true, "search primary", true)


### PR DESCRIPTION
## What

- Added aggregate benchmark and bounded fuzz smoke Make targets for the existing server benchmark and checker, subscriber, and server fuzz entrypoints.
- Added the benchmark aggregate to the CircleCI build after specs and documented the benchmark/fuzz command surface in README and AGENTS guidance.
- Moved existing fuzz and benchmark rationale comments onto the entrypoint doc comments so the purpose is visible at the function boundary.

## Why

- Makes benchmark and fuzz smoke coverage discoverable through repository Make targets instead of requiring manual target construction.
- Aligns this repository with the benchmark/fuzz workflow shape used in the referenced go-service PR while keeping the scope limited to existing checks.
- Ensures the supported benchmark aggregate is exercised by CI.

## Testing

- `make benchmarks` - passed
- `make fuzz-smoke` - passed
- `make lint` - passed with the existing `gomodguard` deprecation warning and 0 issues
- `make sec` - passed; govulncheck and Trivy reported no vulnerabilities
- `make -n benchmarks` - passed
- `make -n fuzz-smoke` - passed
- `git diff --check` - passed
- `make specs` and `make coverage` were not run locally for this scoped workflow change.

AI-assisted-by: [Codex](https://openai.com/codex/)
