### PR TITLE
build(make): run bounded fuzzing in ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,7 @@ jobs:
             - ~/.cache/golangci-lint
       - run: make sec
       - run: make specs
+      - run: make fuzzes
       - run: make benchmarks
       - save_cache:
           name: save go build cache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,10 +86,10 @@ make lint
 make fix-lint     # auto-fix what can be fixed
 make sec
 make specs
-make benchmark    # defaults to package=server; set package=... to override
+make package=server benchmark
 make benchmarks   # aggregate benchmark target
 make fuzz package=checker name=FuzzHTTPCheckerRequestAndStatus
-make fuzz-smoke   # bounded fuzz smoke tests; set fuzztime=... to override
+make fuzzes       # bounded fuzz smoke tests; set fuzztime=... to override
 make coverage     # generate HTML and function coverage summaries
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,6 @@
-REQUESTED_PACKAGE := $(value package)
-
 include bin/build/make/help.mak
 include bin/build/make/go.mak
 include bin/build/make/git.mak
-
-ifeq ($(REQUESTED_PACKAGE),)
-benchmark benchmark-pprof: package = server
-endif
 
 # Run all the benchmarks.
 benchmarks: server-benchmarks
@@ -15,7 +9,7 @@ server-benchmarks:
 	@$(MAKE) package=server benchtime=100x benchmark
 
 # Run bounded fuzz smoke tests. Set fuzztime=<duration> to override the default 1s per target.
-fuzz-smoke: checker-fuzz subscriber-fuzz server-fuzz
+fuzzes: checker-fuzz subscriber-fuzz server-fuzz
 
 checker-fuzz:
 	@$(MAKE) package=checker name=FuzzHTTPCheckerRequestAndStatus fuzztime=$(or $(fuzztime),1s) fuzz

--- a/README.md
+++ b/README.md
@@ -444,7 +444,7 @@ make coverage
 Benchmarks:
 
 ```sh
-make benchmark # defaults to the server package; set package=... to override
+make package=server benchmark
 make benchmarks
 make server-benchmarks
 ```
@@ -452,7 +452,7 @@ make server-benchmarks
 Fuzz smoke tests:
 
 ```sh
-make fuzz-smoke
+make fuzzes
 make checker-fuzz
 make subscriber-fuzz
 make server-fuzz


### PR DESCRIPTION
## What

- Rename the bounded fuzz aggregate target from `fuzz-smoke` to `fuzzes` and remove the old target as an intentional compatibility break.
- Add `make fuzzes` to the CircleCI build after specs so bounded fuzzing runs before benchmarks and coverage.
- Remove the repository-local default that made plain `make benchmark` and `make benchmark-pprof` use the server package, and update README and agent guidance to show the explicit server benchmark command.

## Why

- Keeps the local fuzz command name aligned with the requested command surface and makes CI exercise the same aggregate fuzz target contributors can run locally.
- Avoids hiding package selection behind a root Makefile override now that explicit benchmark commands are preferred.

## Testing

- `make -n fuzzes` - passed
- `make -n fuzz-smoke` - failed as expected with no target, confirming the intentional compatibility break
- `make -n benchmark` - passed
- `make -n benchmark-pprof` - passed
- `make -n benchmarks` - passed
- `make fuzzes` - passed
- `make lint` - passed with 0 issues; golangci-lint also printed the existing `gomodguard` deprecation warning
- `git diff --check` - passed
