### PR TITLE
feat(checker): stop forwarding headers to redirects

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ import "github.com/alexfalkowski/go-health/v2/server"
   also be safe for the concurrent calls you expect.
 - Custom checkers shared across registrations should also be safe for
   concurrent `Check` calls; service startup starts probes concurrently.
-- `HTTPChecker` treats HTTP status codes below `400` as healthy and wraps
-  `checker.ErrInvalidStatusCode` for `4xx` and `5xx` responses.
+- `HTTPChecker` treats `2xx` HTTP status codes as healthy, does not follow
+  redirects, and wraps `checker.ErrInvalidStatusCode` for other responses.
 - `DBChecker` and `TCPChecker` use `checker.ErrTimeout` as the timeout cause for
   their derived per-call contexts.
 - `OnlineChecker` reports healthy if any configured URL returns `200 OK` or
@@ -234,10 +234,9 @@ func waitForUpdate(updates <-chan error, match func(error) bool) bool {
 
 ### 🌐 HTTP checker
 
-`HTTPChecker` performs a `GET` request using the standard `net/http` client
-redirect behavior, then evaluates the response returned by that client. Status
-codes below `400` are considered healthy; `4xx` and `5xx` responses are
-unhealthy.
+`HTTPChecker` performs a `GET` request and evaluates the direct response from
+that endpoint. It does not follow redirects. `2xx` status codes are considered
+healthy; other responses are unhealthy.
 
 ```go
 check := checker.NewHTTPChecker("https://example.com/health", 5*time.Second)

--- a/checker/doc.go
+++ b/checker/doc.go
@@ -35,8 +35,9 @@
 //   - https://connectivity-check.ubuntu.com
 //
 // HTTPChecker can attach static request headers with WithHeader. HTTPChecker
-// and OnlineChecker use http.DefaultTransport by default, and TCPChecker uses
-// net.DefaultDialer by default.
+// does not follow redirects. HTTPChecker and OnlineChecker use
+// http.DefaultTransport by default, and TCPChecker uses net.DefaultDialer by
+// default.
 //
 // # Options
 //

--- a/checker/fuzz_test.go
+++ b/checker/fuzz_test.go
@@ -16,7 +16,7 @@ import (
 func FuzzHTTPCheckerRequestAndStatus(f *testing.F) {
 	f.Add("https://example.com/health", 200, "X-Health-Check", "readyz")
 	f.Add("https://example.com/health", 204, "Authorization", "Bearer token")
-	f.Add("https://example.com/health", 399, "X-Health-Check", "livez")
+	f.Add("https://example.com/health", 302, "X-Health-Check", "livez")
 	f.Add("https://example.com/health", 400, "X-Health-Check", "readyz")
 	f.Add("https://example.com/health", 500, "X-Health-Check", "readyz")
 	f.Add("://bad-url", 200, "X-Health-Check", "readyz")
@@ -44,7 +44,7 @@ func FuzzHTTPCheckerRequestAndStatus(f *testing.F) {
 		if headerName != "" {
 			require.Equal(t, headerValue, transport.request.Header.Get(headerName))
 		}
-		if status >= http.StatusBadRequest {
+		if status < http.StatusOK || status >= http.StatusMultipleChoices {
 			require.ErrorIs(t, err, checker.ErrInvalidStatusCode)
 			return
 		}

--- a/checker/http.go
+++ b/checker/http.go
@@ -10,7 +10,7 @@ import (
 
 var _ Checker = (*HTTPChecker)(nil)
 
-// ErrInvalidStatusCode is returned when the response status code is in the 4xx or 5xx range.
+// ErrInvalidStatusCode is returned when the response status code is outside the 2xx range.
 var ErrInvalidStatusCode = errors.New("invalid status code")
 
 // NewHTTPChecker returns an HTTPChecker that performs an HTTP GET request to url.
@@ -25,16 +25,19 @@ func NewHTTPChecker(url string, t time.Duration, opts ...Option) *HTTPChecker {
 	return &HTTPChecker{
 		url:     url,
 		headers: options.headers.Clone(),
-		client:  &http.Client{Transport: options.roundTripper, Timeout: timeout(t)},
+		client: &http.Client{
+			Transport:     options.roundTripper,
+			Timeout:       timeout(t),
+			CheckRedirect: noRedirect,
+		},
 	}
 }
 
 // HTTPChecker performs an HTTP GET request to a URL.
 //
-// HTTPChecker uses the standard net/http client redirect behavior before
-// evaluating the response returned by that client. Responses with status codes
-// below 400 are considered healthy. Responses with status codes in the 4xx or
-// 5xx range return ErrInvalidStatusCode wrapped with context.
+// HTTPChecker does not follow redirects. Responses with status codes in the 2xx
+// range are considered healthy. Other responses return ErrInvalidStatusCode
+// wrapped with context.
 type HTTPChecker struct {
 	client  *http.Client
 	headers http.Header
@@ -65,9 +68,13 @@ func (c *HTTPChecker) Check(ctx context.Context) error {
 	}
 	defer response.Body.Close()
 
-	if response.StatusCode >= http.StatusBadRequest {
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
 		return fmt.Errorf("http checker: %w", ErrInvalidStatusCode)
 	}
 
 	return nil
+}
+
+func noRedirect(*http.Request, []*http.Request) error {
+	return http.ErrUseLastResponse
 }

--- a/checker/http_test.go
+++ b/checker/http_test.go
@@ -19,7 +19,9 @@ func TestHTTPCheckerStatusCodes(t *testing.T) {
 		wantInvalidStatus bool
 	}{
 		{name: "ok", status: http.StatusOK},
-		{name: "not modified", status: http.StatusNotModified},
+		{name: "no content", status: http.StatusNoContent},
+		{name: "redirect", status: http.StatusFound, wantInvalidStatus: true},
+		{name: "not modified", status: http.StatusNotModified, wantInvalidStatus: true},
 		{name: "bad request", status: http.StatusBadRequest, wantInvalidStatus: true},
 		{name: "server error", status: http.StatusInternalServerError, wantInvalidStatus: true},
 	}
@@ -43,6 +45,37 @@ func TestHTTPCheckerStatusCodes(t *testing.T) {
 			}
 			require.ErrorIs(t, err, checker.ErrInvalidStatusCode)
 		})
+	}
+}
+
+func TestHTTPCheckerDoesNotFollowRedirects(t *testing.T) {
+	t.Parallel()
+
+	redirected := make(chan http.Header, 1)
+	target := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		redirected <- r.Header.Clone()
+	}))
+	t.Cleanup(target.Close)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Location", target.URL)
+		w.WriteHeader(http.StatusFound)
+	}))
+	t.Cleanup(upstream.Close)
+
+	check := checker.NewHTTPChecker(
+		upstream.URL,
+		time.Second,
+		checker.WithHeader("X-Health-Token", "secret"),
+	)
+
+	err := check.Check(t.Context())
+
+	require.ErrorIs(t, err, checker.ErrInvalidStatusCode)
+	select {
+	case headers := <-redirected:
+		require.Failf(t, "redirect target received request", "headers: %v", headers)
+	default:
 	}
 }
 


### PR DESCRIPTION
## What

- Make HTTPChecker evaluate the direct response without following redirects.
- Treat only 2xx HTTP responses as healthy and classify redirects and other non-2xx responses as invalid status codes.
- Add redirect regression coverage, update the HTTP status fuzz invariant, and align README and GoDoc with the new behavior.

## Why

- Custom health-check headers such as X-Health-Token should not be forwarded to redirect targets.
- Health checks should validate the configured endpoint directly instead of accepting redirect responses as healthy.

## Testing

- `go test ./checker -run 'TestHTTPChecker(StatusCodes|DoesNotFollowRedirects|Headers)' -count=1` - passed
- `make package=checker specs` - passed
- `make package=checker name=FuzzHTTPCheckerRequestAndStatus fuzztime=1s fuzz` - passed
- `make specs` - passed
- `make lint` - passed
- `make sec` - passed
