### PR TITLE
build(make): use counted fuzz smoke runs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ make specs
 make package=server benchmark
 make benchmarks   # aggregate benchmark target
 make fuzz package=checker name=FuzzHTTPCheckerRequestAndStatus
-make fuzzes       # bounded fuzz smoke tests; set fuzztime=... to override
+make fuzzes       # bounded fuzz smoke tests; set fuzztime=<count>x to override
 make coverage     # generate HTML and function coverage summaries
 ```
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+fuzztime ?= 1000x
+
 include bin/build/make/help.mak
 include bin/build/make/go.mak
 include bin/build/make/git.mak
@@ -8,15 +10,15 @@ benchmarks: server-benchmarks
 server-benchmarks:
 	@$(MAKE) package=server benchtime=100x benchmark
 
-# Run bounded fuzz smoke tests. Set fuzztime=<duration> to override the default 1s per target.
+# Run bounded fuzz smoke tests. Set fuzztime=<count>x to override the default 1000x per target.
 fuzzes: checker-fuzz subscriber-fuzz server-fuzz
 
 checker-fuzz:
-	@$(MAKE) package=checker name=FuzzHTTPCheckerRequestAndStatus fuzztime=$(or $(fuzztime),1s) fuzz
-	@$(MAKE) package=checker name=FuzzOnlineCheckerURLsAndStatuses fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=checker name=FuzzHTTPCheckerRequestAndStatus fuzz
+	@$(MAKE) package=checker name=FuzzOnlineCheckerURLsAndStatuses fuzz
 
 subscriber-fuzz:
-	@$(MAKE) package=subscriber name=FuzzErrorsAggregationAndCopy fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=subscriber name=FuzzErrorsAggregationAndCopy fuzz
 
 server-fuzz:
-	@$(MAKE) package=server name=FuzzServiceObserveValidation fuzztime=$(or $(fuzztime),1s) fuzz
+	@$(MAKE) package=server name=FuzzServiceObserveValidation fuzz

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ make fuzzes
 make checker-fuzz
 make subscriber-fuzz
 make server-fuzz
-make package=checker name=FuzzHTTPCheckerRequestAndStatus fuzztime=10s fuzz
+make package=checker name=FuzzHTTPCheckerRequestAndStatus fuzztime=1000x fuzz
 ```
 
 Local test notes:


### PR DESCRIPTION
## What

- Default this repository fuzz smoke workflow to count-based runs with `fuzztime ?= 1000x`.
- Let grouped fuzz targets inherit the repository default instead of forcing `1s` per target.
- Update README and agent command guidance to show count-based `fuzztime` usage.

## Why

- Duration-based fuzz smoke runs were causing timeouts in CI/local workflows.
- Count-based runs keep the smoke checks bounded by executions while preserving caller overrides through the existing `fuzztime` variable.

## Testing

- `make lint` - passed
- `make fuzzes` - passed
- `make package=checker name=FuzzHTTPCheckerRequestAndStatus fuzz` - passed
- `make fuzztime=25x package=subscriber name=FuzzErrorsAggregationAndCopy fuzz` - passed
