### PR TITLE
docs(readme): clarify repeat start/stop and pre-start cleanup lifecycle semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ import "github.com/alexfalkowski/go-health/v2/server"
   `Start` returns, typically during process shutdown.
 - Use a shutdown context that can remain valid until `Stop` finishes cleanup; if
   `Stop` returns the supplied context error, cleanup did not complete.
+- Repeat lifecycle calls are safe: calling `server.Start` again while running is
+  a no-op, and calling `server.Stop` before `Start` or after a prior `Stop` is a
+  no-op. The same applies to `server.Service`, and `Service.Stop` without a prior
+  `Start` still releases observers created by `Observe`.
 - A probe with an invalid period emits a single error tick and closes.
 
 ### 🧩 Registration and observers

--- a/server/server.go
+++ b/server/server.go
@@ -151,7 +151,9 @@ func (s *Server) Observe(name, kind string, names ...string) error {
 // Start is intended to be called once after setup. It waits for each service's
 // initial checks before returning; call Stop once after Start has returned
 // during normal shutdown. If a service fails to start, Start stops any services
-// started during that attempt and leaves the server stopped.
+// started during that attempt and leaves the server stopped. Calling Start
+// again with a live context while the server is already running is a no-op that
+// returns nil.
 func (s *Server) Start(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -182,7 +184,8 @@ func (s *Server) Start(ctx context.Context) error {
 //
 // Stop is intended to be called once after Start returns. Use a context that can
 // remain valid until cleanup completes; if ctx expires before shutdown work
-// finishes, Stop returns ctx.Err().
+// finishes, Stop returns ctx.Err(). Calling Stop before Start or after a prior
+// Stop is a no-op and returns nil.
 func (s *Server) Stop(ctx context.Context) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()

--- a/server/service.go
+++ b/server/service.go
@@ -131,7 +131,8 @@ func (s *Service) Observe(kind string, names ...string) error {
 // returning; observer state is updated asynchronously after those ticks are
 // fanned out. Call Stop once after Start has returned during normal shutdown. If
 // a probe fails to start, Start cleans up partially started probes and
-// subscriptions and leaves the service stopped.
+// subscriptions and leaves the service stopped. Calling Start again with a live
+// context while the service is already running is a no-op that returns nil.
 func (s *Service) Start(ctx context.Context) error {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -166,7 +167,9 @@ func (s *Service) Start(ctx context.Context) error {
 // Stop waits for in-flight fan-in and fan-out work to finish before returning.
 // It is intended to be called once after Start returns. Use a context that can
 // remain valid until cleanup completes; if ctx expires before shutdown work
-// finishes, Stop returns ctx.Err().
+// finishes, Stop returns ctx.Err(). Calling Stop before Start or after a prior
+// Stop still releases observers created by Observe and returns nil, or ctx.Err()
+// if ctx expires first.
 func (s *Service) Stop(ctx context.Context) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()


### PR DESCRIPTION
## What

- Document the repeat-call and pre-`Start` lifecycle semantics on the `server` package's `Server.Start`/`Server.Stop` and `Service.Start`/`Service.Stop`, which previously only said they were "intended to be called once" without stating what a second (or pre-`Start`) call does.
- `Server.Start` / `Service.Start`: a repeat call with a live context while already running is a no-op that returns nil.
- `Server.Stop`: a call before `Start` or after a prior `Stop` is a no-op that returns nil.
- `Service.Stop`: a call before `Start` or after a prior `Stop` still releases the observers created by `Observe` (whose goroutines start immediately) and returns nil, or `ctx.Err()` if the context expires first.
- Add a parallel "Repeat lifecycle calls are safe" bullet to the README "Key behaviors" section, mirroring the existing probe lifecycle bullets.
- Documentation only: no behavior, signature, or example changes.

## Why

- The `checker`, `probe`, and `subscriber` layers already document their idempotency, but the primary entry points (`Server` and `Service`) were silent on repeat-call behavior. Service authors who guard shutdown with a `defer Stop()` plus an explicit `Stop()` on a signal, or who retry `Start`, had no documented contract for whether that is safe.
- The `Service.Stop`-before-`Start` path is the only way a direct `Service` consumer releases the observer goroutines created by `Observe` when setup is abandoned before `Start`; leaving it undocumented risked a goroutine leak. This documents the existing behavior without changing any code.

## Testing

- `make lint` - passed (0 issues; golangci-lint including the godot and gofumpt documentation checks)
- `go vet ./server/...` - passed
- `gofmt -l` on the changed Go files - passed (no reformatting needed)
- `make specs` - not run: the change is comment/README-only with no behavior or example-code changes, and the target requires the `STATUS_PORT=6000` status sidecar; CI runs it as additional verification.
- All documented behaviors were verified against the implementation: `server/server.go:163-165` and `:190-192`, `server/service.go:143-145` and `:174-177`, and the immediate observer goroutine start at `subscriber/observer.go:31`.

AI-assisted-by: [Claude Code](https://claude.com/claude-code)
